### PR TITLE
updated fibo example to use new cell manager with customizable column width

### DIFF
--- a/src/compiler/cell_manager.rs
+++ b/src/compiler/cell_manager.rs
@@ -147,7 +147,7 @@ impl CellManager for SingleRowCellManager {
 
 #[derive(Debug, Default)]
 pub struct MaxWidthCellManager {
-    max_width: usize,
+    pub max_width: usize,
 }
 
 impl CellManager for MaxWidthCellManager {


### PR DESCRIPTION
Note that the pragma_last_step constraint for the one column fibo example errors out, with error message below

Basically the message is saying that q_last = 1, and the constraint wants to make q_last * (1 - step selector for last step) = 0, where the step selector is expected to be 1 but returns 0 value. The q_last is fine, but step selector should return 1.

Any quick idea or fix for this?

```rust
Constraint 5 ('q_last => Product(Fixed { query_index: 2, column_index: 2, rotation: Rotation(0) }, Sum(Constant(0x0000000000000000000000000000000000000000000000000000000000000001), Negated(Advice { query_index: 0, column_index: 1, rotation: Rotation(0) })))') in gate 0 ('main') is not satisfied in Region 0 ('circuit') at offset 32
- Column('Advice', 1 - 'step selector for last step')@0 = 0
- Column('Fixed', 2 - q_last)@0 = 1
```