### PR TITLE
Removed leading zeroes for the debug msg of Expr and PolyExpr

### DIFF
--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -31,7 +31,14 @@ pub enum Expr<F> {
 impl<F: Debug> Debug for Expr<F> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Const(arg0) => write!(f, "{:?}", arg0),
+            Self::Const(arg0) => {
+                let mut s = format!("{:?}", arg0)
+                    .trim_start_matches("0x")
+                    .trim_start_matches('0')
+                    .to_string();
+                s.insert_str(0, "0x");
+                write!(f, "{}", s)
+            },
             Self::Sum(arg0) => write!(
                 f,
                 "({})",
@@ -333,5 +340,37 @@ pub mod query {
         fn neg(self) -> Self::Output {
             self.expr().neg()
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use halo2_proofs::halo2curves::bn256::Fr;
+    use super::*;
+
+    #[test]
+    fn test_expr_fmt() {
+        let a: Fr = 10.into();
+        let b: Fr = 20.into();
+
+        let expr1 = Expr::Const(&a);
+        println!("{:?}", expr1);
+        assert_eq!(format!("{:?}", expr1), "0xa");
+
+        let expr2 = Expr::Sum(vec![Expr::Const(&a), Expr::Const(&b)]);
+        println!("{:?}", expr2);
+        assert_eq!(format!("{:?}", expr2), "(0xa + 0x14)");
+
+        let expr3 = Expr::Mul(vec![Expr::Const(&a), Expr::Const(&b)]);
+        println!("{:?}", expr3);
+        assert_eq!(format!("{:?}", expr3), "(0xa * 0x14)");
+
+        let expr4 = Expr::Neg(Box::new(Expr::Const(&a)));
+        println!("{:?}", expr4);
+        assert_eq!(format!("{:?}", expr4), "-0xa");
+
+        let expr5 = Expr::Pow(Box::new(Expr::Const(&a)), 2);
+        println!("{:?}", expr5);
+        assert_eq!(format!("{:?}", expr5), "(0xa)^2");
     }
 }

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -42,7 +42,7 @@ impl<F: Debug> Debug for Expr<F> {
                 } else {
                     write!(f, "{}", formatted)
                 }
-            },
+            }
             Self::Sum(arg0) => write!(
                 f,
                 "({})",
@@ -349,8 +349,8 @@ pub mod query {
 
 #[cfg(test)]
 mod tests {
-    use halo2_proofs::halo2curves::bn256::Fr;
     use super::*;
+    use halo2_proofs::halo2curves::bn256::Fr;
 
     #[test]
     fn test_expr_fmt() {

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -32,12 +32,16 @@ impl<F: Debug> Debug for Expr<F> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Const(arg0) => {
-                let mut s = format!("{:?}", arg0)
-                    .trim_start_matches("0x")
-                    .trim_start_matches('0')
-                    .to_string();
-                s.insert_str(0, "0x");
-                write!(f, "{}", s)
+                let formatted = format!("{:?}", arg0);
+                if formatted.starts_with("0x") {
+                    let s = format!(
+                        "0x{}",
+                        formatted.trim_start_matches("0x").trim_start_matches('0')
+                    );
+                    write!(f, "{}", s)
+                } else {
+                    write!(f, "{}", formatted)
+                }
             },
             Self::Sum(arg0) => write!(
                 f,
@@ -354,23 +358,18 @@ mod tests {
         let b: Fr = 20.into();
 
         let expr1 = Expr::Const(&a);
-        println!("{:?}", expr1);
         assert_eq!(format!("{:?}", expr1), "0xa");
 
         let expr2 = Expr::Sum(vec![Expr::Const(&a), Expr::Const(&b)]);
-        println!("{:?}", expr2);
         assert_eq!(format!("{:?}", expr2), "(0xa + 0x14)");
 
         let expr3 = Expr::Mul(vec![Expr::Const(&a), Expr::Const(&b)]);
-        println!("{:?}", expr3);
         assert_eq!(format!("{:?}", expr3), "(0xa * 0x14)");
 
         let expr4 = Expr::Neg(Box::new(Expr::Const(&a)));
-        println!("{:?}", expr4);
         assert_eq!(format!("{:?}", expr4), "-0xa");
 
         let expr5 = Expr::Pow(Box::new(Expr::Const(&a)), 2);
-        println!("{:?}", expr5);
         assert_eq!(format!("{:?}", expr5), "(0xa)^2");
     }
 }

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -156,12 +156,16 @@ impl<F: Debug> Debug for PolyExpr<F> {
 
         match self {
             Self::Const(arg0) => {
-                let mut s = format!("{:?}", arg0)
-                    .trim_start_matches("0x")
-                    .trim_start_matches('0')
-                    .to_string();
-                s.insert_str(0, "0x");
-                write!(f, "{}", s)
+                let formatted = format!("{:?}", arg0);
+                if formatted.starts_with("0x") {
+                    let s = format!(
+                        "0x{}",
+                        formatted.trim_start_matches("0x").trim_start_matches('0')
+                    );
+                    write!(f, "{}", s)
+                } else {
+                    write!(f, "{}", formatted)
+                }
             },
             Self::Query(_, _, annotation) => write!(f, "`{}`", annotation),
             Self::Sum(arg0) => write!(f, "({})", joiner(arg0, " + ")),
@@ -208,23 +212,18 @@ mod tests {
         let b: Fr = 20.into();
 
         let expr1 = PolyExpr::Const(&a);
-        println!("{:?}", expr1);
         assert_eq!(format!("{:?}", expr1), "0xa");
 
         let expr2 = PolyExpr::Sum(vec![PolyExpr::Const(&a), PolyExpr::Const(&b)]);
-        println!("{:?}", expr2);
         assert_eq!(format!("{:?}", expr2), "(0xa + 0x14)");
 
         let expr3 = PolyExpr::Mul(vec![PolyExpr::Const(&a), PolyExpr::Const(&b)]);
-        println!("{:?}", expr3);
         assert_eq!(format!("{:?}", expr3), "(0xa * 0x14)");
 
         let expr4 = PolyExpr::Neg(Box::new(PolyExpr::Const(&a)));
-        println!("{:?}", expr4);
         assert_eq!(format!("{:?}", expr4), "(-0xa)");
 
         let expr5 = PolyExpr::Pow(Box::new(PolyExpr::Const(&a)), 2);
-        println!("{:?}", expr5);
         assert_eq!(format!("{:?}", expr5), "Pow(0xa, 2)");
     }
 }

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -166,7 +166,7 @@ impl<F: Debug> Debug for PolyExpr<F> {
                 } else {
                     write!(f, "{}", formatted)
                 }
-            },
+            }
             Self::Query(_, _, annotation) => write!(f, "`{}`", annotation),
             Self::Sum(arg0) => write!(f, "({})", joiner(arg0, " + ")),
             Self::Mul(arg0) => write!(f, "({})", joiner(arg0, " * ")),


### PR DESCRIPTION
- Only done for Const enum types, because other types don't involve leading zeroes (they can be composed of Const type though)
- Wrote test cases as well

I think the debug msg for the entire circuit is still from Halo2 native, and it doesn't remove leading zeroes. There's probably no way we can fix that unless we change the dependencies ourselves.