### PR TITLE
improve: use closure in add_lookup

### DIFF
--- a/examples/example.rs
+++ b/examples/example.rs
@@ -3,7 +3,7 @@ use chiquito::{
     compiler::{
         cell_manager::SingleRowCellManager, step_selector::SimpleStepSelectorBuilder, Compiler,
     },
-    dsl::{cb::lookup, circuit},
+    dsl::circuit,
 };
 use halo2_proofs::halo2curves::bn256::Fr;
 
@@ -23,7 +23,9 @@ fn main() {
                 ctx.constr(1.expr() + (a + b) * (c - 1));
                 ctx.transition(a + 1);
 
-                ctx.add_lookup(lookup().add(a, b).enable(d).add(d + a, f * c));
+                ctx.add_lookup(|lookup| {
+                    lookup.add(a, b).enable(d).add(d + a, f * c);
+                });
             });
 
             ctx.wg(move |ctx, _| {

--- a/examples/mimc7.rs
+++ b/examples/mimc7.rs
@@ -74,7 +74,9 @@ fn mimc7_circuit<F: PrimeField>(
                 ctx.transition(eq(row, 0));
                 ctx.transition(eq(row + 1, row.next()));
 
-                ctx.add_lookup(lookup().add(row, lookup_row).add(c, lookup_c));
+                ctx.add_lookup(|lookup| {
+                    lookup.add(row, lookup_row).add(c, lookup_c);
+                });
             });
 
             ctx.wg(move |ctx, (x_value, k_value, c_value, row_value)| {
@@ -103,7 +105,9 @@ fn mimc7_circuit<F: PrimeField>(
                 ctx.transition(eq(k, k.next()));
                 ctx.transition(eq(row + 1, row.next()));
 
-                ctx.add_lookup(lookup().add(row, lookup_row).add(c, lookup_c));
+                ctx.add_lookup(|lookup| {
+                    lookup.add(row, lookup_row).add(c, lookup_c);
+                });
             });
 
             ctx.wg(move |ctx, (x_value, k_value, c_value, row_value)| {

--- a/src/dsl.rs
+++ b/src/dsl.rs
@@ -8,7 +8,7 @@ use halo2_proofs::plonk::{Advice, Column as Halo2Column, Fixed};
 
 use core::fmt::Debug;
 
-use self::cb::{Constraint, LookupBuilder, Typing};
+use self::cb::{lookup, Constraint, LookupBuilder, Typing};
 
 /// A generic structure designed to handle the context of a circuit for generic types `F`,
 /// `TraceArgs` and `StepArgs`. The struct contains a `Circuit` instance and implements
@@ -223,7 +223,12 @@ impl<'a, F, Args> StepTypeSetupContext<'a, F, Args> {
 
 impl<'a, F: Debug + Clone, Args> StepTypeSetupContext<'a, F, Args> {
     /// Adds a lookup to the step type.
-    pub fn add_lookup(&mut self, lookup_builder: &mut LookupBuilder<F>) {
+    pub fn add_lookup<D>(&mut self, lookup_handler: D)
+    where
+        D: FnOnce(&mut LookupBuilder<F>),
+    {
+        let mut lookup_builder = lookup();
+        lookup_handler(&mut lookup_builder);
         self.step_type.lookups.push(lookup_builder.lookup.clone());
     }
 }


### PR DESCRIPTION
Using closure in `add_lookup` can avoid exposing the details of `LookupBuilder`, and maybe will be good for lazy execution in the future.