### PR TITLE
lookup table abstraction proposal

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -392,3 +392,43 @@ impl<CT: ColumnType> ImportedHalo2Column<CT> {
 
 pub type ImportedHalo2Advice = ImportedHalo2Column<Advice>;
 pub type ImportedHalo2Fixed = ImportedHalo2Column<Fixed>;
+
+pub struct LookupTableRegistry<F> {
+    pub lookup_tables: HashMap<u32, LookupTable<F>>,
+    pub annotations: HashMap<u32, String>,
+}
+
+impl<F> LookupTableRegistry<F> {
+    pub(crate) fn new() -> Self {
+        Self {
+            lookup_tables: HashMap::new(),
+            annotations: HashMap::new(),
+        }
+    }
+}
+
+impl<F: Clone> LookupTableRegistry<F> {
+    pub(crate) fn add_lookup_table(&mut self, lookup_table: LookupTable<F>) {
+        self.lookup_tables
+            .insert(lookup_table.id, lookup_table.clone());
+        self.annotations
+            .insert(lookup_table.id, lookup_table.annotation);
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct LookupTable<F> {
+    pub id: u32,
+    pub annotation: String,
+    pub destination_columns: Vec<Expr<F>>,
+}
+
+impl<F> LookupTable<F> {
+    pub fn new(id: u32, annotation: String, destination_columns: Vec<Expr<F>>) -> Self {
+        Self {
+            id,
+            annotation,
+            destination_columns,
+        }
+    }
+}

--- a/src/dsl.rs
+++ b/src/dsl.rs
@@ -305,6 +305,8 @@ pub fn lookup_table_registry<F>() -> LookupTableRegistry<F> {
     LookupTableRegistry::new()
 }
 
+// TODO: I want a `add_lookup_table` method where I don't need to pass in lookup_table_registry as a parameter.
+// Need a way to make lookup_table_registry globally static.
 pub fn add_lookup_table<F: Debug + Clone, E: Into<Expr<F>>>(
     registry: &mut LookupTableRegistry<F>, 
     name: &str, 

--- a/src/dsl/cb.rs
+++ b/src/dsl/cb.rs
@@ -416,6 +416,8 @@ impl<F: Debug + Clone> LookupBuilder<F> {
         self
     }
 
+    // TODO: I want a `table` method where I don't need to pass in lookup_table_registry as a parameter.
+    // Need a way to make lookup_table_registry globally static.
     pub fn table(&mut self, registry: &LookupTableRegistry<F>, handler: LookupTableHandler) -> &mut Self {
         if self.lookup_table.is_some() {
             panic!("Lookup table is already set.");


### PR DESCRIPTION
Created a draft PR as it's not much harder than a proposal. MiMC7 example shows usage that doesn't work yet. I think I'm at a point of needing additional guidance.

Overall, I think my biggest issue is with creating LookupTableRegistry as a global static variable that the user can use as a mutable reference within a circuit or step type closure without moving. It's like the global context of THE registry. I end up still needing to pass it in as a parameter for some functions, and therefore have the same issue with moving.

Other than that, I opted to modify the original LookupBuilder. Most notably, I added a `table` method that adds a LookupTable to a LookupBuilder, which can `apply` and `enable` thereafter. The previous LookupTable methods of returning a Lookup don't work any more, because we need nested methods (e.g. apply().enable()), and because Lookup needs to stay in ast, so we can't directly call Lookup methods to modify it.