### PR TITLE
issue 48 part 2: compiler and ir 

### DIFF
--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -257,6 +257,10 @@ pub mod query {
             }
         }
 
+        /// Call `prev` function on a `Querible` shared signal to build constraints for shared
+        /// signal that decreases rotation by 1. Must be called on a shared signal and used within a
+        /// `transition` constraint. Returns a new `Queriable` shared signal with positive or
+        /// negative rotation.
         pub fn prev(&self) -> Queriable<F> {
             use Queriable::*;
             match self {
@@ -265,6 +269,10 @@ pub mod query {
             }
         }
 
+        /// Call `rot` function on a `Querible` shared signal to build constraints for shared signal
+        /// with arbitrary rotation. Must be called on a shared signal and used within a
+        /// `transition` constraint. Returns a new `Queriable` shared signal with positive or
+        /// negative rotation.
         pub fn rot(&self, rotation: i32) -> Queriable<F> {
             use Queriable::*;
             match self {

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -209,7 +209,9 @@ pub mod query {
     };
 
     use crate::{
-        ast::{ForwardSignal, ImportedHalo2Advice, ImportedHalo2Fixed, InternalSignal, SharedSignal},
+        ast::{
+            ForwardSignal, ImportedHalo2Advice, ImportedHalo2Fixed, InternalSignal, SharedSignal,
+        },
         dsl::StepTypeHandler,
     };
 

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -9,7 +9,7 @@ use halo2_proofs::{
 use crate::{
     ast::{
         query::Queriable, Circuit as astCircuit, Expr, ForwardSignal, ImportedHalo2Advice,
-        ImportedHalo2Fixed, StepType,
+        ImportedHalo2Fixed, SharedSignal, StepType,
     },
     dsl::StepTypeHandler,
     ir::{Circuit, Column, ColumnType, Poly, PolyExpr, PolyLookup},
@@ -51,6 +51,7 @@ pub struct CompilationUnit<F, StepArgs> {
     pub selector: StepSelector<F, StepArgs>,
     pub step_types: HashMap<u32, Rc<StepType<F, StepArgs>>>,
     pub forward_signals: Vec<ForwardSignal>,
+    pub shared_signals: Vec<SharedSignal>,
 
     pub annotations: HashMap<u32, String>,
 
@@ -67,6 +68,7 @@ impl<F, StepArgs> Default for CompilationUnit<F, StepArgs> {
             selector: Default::default(),
             step_types: Default::default(),
             forward_signals: Default::default(),
+            shared_signals: Default::default(),
 
             annotations: Default::default(),
 
@@ -172,6 +174,7 @@ impl<CM: CellManager, SSB: StepSelectorBuilder> Compiler<CM, SSB> {
         unit.columns = vec![halo2_advice_columns, halo2_fixed_columns].concat();
         unit.step_types = sc.step_types.clone();
         unit.forward_signals = sc.forward_signals.clone();
+        unit.shared_signals = sc.shared_signals.clone();
 
         self.cell_manager.place(&mut unit);
 
@@ -383,6 +386,29 @@ impl<CM: CellManager, SSB: StepSelectorBuilder> Compiler<CM, SSB> {
                         format!(
                             "{}[{}, {}]",
                             annotation, placement.column.annotation, super_rotation
+                        )
+                    }
+                } else {
+                    format!("[{}, {}]", placement.column.annotation, super_rotation)
+                };
+                PolyExpr::Query(placement.column, super_rotation, annotation)
+            }
+            Queriable::Shared(shared, rot) => {
+                let placement = unit.placement.get_shared_placement(&shared);
+
+                let super_rotation =
+                    placement.rotation + rot * (unit.placement.step_height(step) as i32);
+
+                let annotation = if let Some(annotation) = unit.annotations.get(&shared.uuid()) {
+                    if rot == 0 {
+                        format!(
+                            "{}[{}, {}]",
+                            annotation, placement.column.annotation, super_rotation
+                        )
+                    } else {
+                        format!(
+                            "shared_rot_{}({})[{}, {}]",
+                            rot, annotation, placement.column.annotation, super_rotation
                         )
                     }
                 } else {

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -178,6 +178,10 @@ impl<CM: CellManager, SSB: StepSelectorBuilder> Compiler<CM, SSB> {
 
         self.cell_manager.place(&mut unit);
 
+        if !unit.shared_signals.is_empty() && !unit.placement.same_height() {
+            panic!("Shared signals are not supported for circuits with different step heights. Using a different cell manager might fix this problem.");
+        }
+
         for forward_signal in sc.exposed.clone() {
             let forward_placement = unit.placement.get_forward_placement(&forward_signal);
             let exposed = (forward_placement.column, forward_placement.rotation);

--- a/src/compiler/cell_manager.rs
+++ b/src/compiler/cell_manager.rs
@@ -204,13 +204,13 @@ impl CellManager for MaxWidthCellManager {
         // have the same height.
         if !unit.shared_signals.is_empty() {
             let max_width = self.max_width;
-            let mut signal_len_by_step_type = unit.step_types.values().map(|step_type| {
+            let mut height_by_step_type = unit.step_types.values().map(|step_type| {
                 (step_type.signals.len() + unit.forward_signals.len() + unit.shared_signals.len())
                     .div(max_width)
                     + 1
             });
-            let first = signal_len_by_step_type.next().unwrap();
-            if !signal_len_by_step_type.all(|len| len == first) {
+            let first = height_by_step_type.next().unwrap();
+            if !height_by_step_type.all(|len| len == first) {
                 panic!("To use shared signal, all steps placed by MaxWidthCellManager need to have the same height. Please use a different cell manager.");
             }
         }

--- a/src/dsl.rs
+++ b/src/dsl.rs
@@ -33,6 +33,10 @@ impl<F, TraceArgs, StepArgs> CircuitContext<F, TraceArgs, StepArgs> {
         Queriable::Forward(self.sc.add_forward(name, phase), false)
     }
 
+    pub fn shared(&mut self, name: &str) -> Queriable<F> {
+        Queriable::Shared(self.sc.add_shared(name, 0), 0)
+    }
+
     /// Exposes the first step instance value of a forward signal as public.
     pub fn expose(&mut self, forward: Queriable<F>) {
         match forward {

--- a/src/dsl.rs
+++ b/src/dsl.rs
@@ -33,8 +33,16 @@ impl<F, TraceArgs, StepArgs> CircuitContext<F, TraceArgs, StepArgs> {
         Queriable::Forward(self.sc.add_forward(name, phase), false)
     }
 
+    /// Adds a shared signal to the circuit with a name string and zero rotation and returns a
+    /// `Queriable` instance representing the added shared signal.
     pub fn shared(&mut self, name: &str) -> Queriable<F> {
         Queriable::Shared(self.sc.add_shared(name, 0), 0)
+    }
+
+    /// Adds a shared signal to the circuit with a name string and a specified phase and returns a
+    /// `Queriable` instance representing the added shared signal.
+    pub fn shared_with_phase(&mut self, name: &str, phase: usize) -> Queriable<F> {
+        Queriable::Shared(self.sc.add_shared(name, phase), 0)
     }
 
     /// Exposes the first step instance value of a forward signal as public.


### PR DESCRIPTION
PR'ed against another branch (issue 48 part 1).

IR didn't need to change, because all signals are compiled into ir::Column and Placement, which is defined in compiler/cell manager.