### PR TITLE
Example/forth

### DIFF
--- a/examples/forth.rs
+++ b/examples/forth.rs
@@ -52,8 +52,6 @@ fn forth_circuit<F: Field + From<u64>>() -> (Circuit<F>, Option<AssigmentGenerat
 
         // addition operation step
         let add_step = ctx.step_type_def("add", |ctx| {
-            // We use a fixed signal to represent the result
-            let r = ctx.fixed("r");
             ctx.setup(move |ctx| {
                 ctx.constr(eq(s1 + s2, r));
             });
@@ -129,5 +127,21 @@ fn forth_circuit<F: Field + From<u64>>() -> (Circuit<F>, Option<AssigmentGenerat
 fn main() {
     let (chiquito, wit_gen) = forth_circuit::<Fr>();
     let compiled = chiquito2Halo2(chiquito);
-    let circuit = ChiquitoHalo2Circuit::new(compiled, wit_gen.map(|g| g.generate()));
+    // passing 0 as the TraceArgs argument for g.generate as somewhat of a placeholder since TraceArgs aren't used in this example
+    let circuit = ChiquitoHalo2Circuit::new(compiled, wit_gen.map(|g| g.generate(0)));
+    println!("Compiled circuit: {:?}", circuit);
+
+    let prover = MockProver::<Fr>::run(7, &circuit, Vec::new()).unwrap();
+
+    let result = prover.verify_par();
+
+    println!("{:#?}", result);
+
+    if let Err(failures) = &result {
+        for failure in failures.iter() {
+            println!("{}", failure);
+        }
+    }
+
+    // Is the plaf boilerplate required?
 }

--- a/examples/forth.rs
+++ b/examples/forth.rs
@@ -68,6 +68,9 @@ fn forth_circuit<F: Field + From<u64>>() -> (Circuit<F>, Option<AssigmentGenerat
                         panic!("invalid operation")
                     }
                 }
+
+                // initialize lookup
+                ctx.add_lookup(lookup().add(o, operation_lookup));
             });
         });
     });

--- a/examples/forth.rs
+++ b/examples/forth.rs
@@ -21,10 +21,9 @@ use chiquito::{
 use halo2curves::ff::Field;
 
 // Generic types:
-// 1) F for a type that implements the field element trait
-// 2) (u64, u64) are the elements that are in the stack; the stack is made up of two signals with many steps so each basic operation consumes 1 step
-// 3) u8 for the operation; we will map 1 -> +, 2 -> -, 3 -> *, 4 -> /
-// 4) u64 for the result of the operation
+// 1) (F, F) are the elements that are in the stack; the stack is made up of two signals with many steps so each basic operation consumes 1 step
+// 2) F for the operation; we will map 1 -> +, 2 -> -, 3 -> *, 4 -> / ; these will be constrained with a lookup table
+// 3) F for the result of the operation
 fn forth_circuit<F: Field + From<u64>>() -> (Circuit<F>, Option<AssigmentGenerator<F, ()>>) {
     // PLONKish table for the FORTH stack:
     // | s1 | s2 | o | r |
@@ -32,5 +31,25 @@ fn forth_circuit<F: Field + From<u64>>() -> (Circuit<F>, Option<AssigmentGenerat
     // |  3 |  2 | 3 | 6 |
     // |  4 |  2 | 4 | 2 |
 
-    
+    let forth = circuit::<(F, F), F>("FORTH", |ctx| {
+
+        let s1 = ctx.forward("s1");
+        let s2 = ctx.forward("s2");
+        let o = ctx.forward("o");
+        let r = ctx.forward("r");
+
+        let operation_lookup: Queriable<(F, F)> = ctx.fixed("op lookup");
+
+        // populate lookup column; this can be increased as more operations are added (e.g. 5 -> %, 6 -> ^, etc.)
+        ctx.fixed_gen(move |ctx| {
+            for i in 1..=4 {
+                ctx.assign(i, operation_lookup, F::from(i as u64));
+            }
+        });
+
+        // stack operation step
+        let stack_step = ctx.step_type_def("stack step", |ctx| {
+            
+        });
+    });
 }

--- a/examples/forth.rs
+++ b/examples/forth.rs
@@ -1,12 +1,5 @@
 use chiquito::{
-    ast::expr::*,
-    backend::halo2::{chiquito2Halo2, ChiquitoHalo2Circuit}, /* compiles to
-                                                             * Chiquito Halo2
-                                                             * backend,
-                                                             * which can be
-                                                             * integrated into
-                                                             * Halo2
-                                                             * circuit */
+    backend::halo2::{chiquito2Halo2, ChiquitoHalo2Circuit}, 
     compiler::{
         cell_manager::SingleRowCellManager, // input for constructing the compiler
         step_selector::SimpleStepSelectorBuilder, // input for constructing the compiler
@@ -18,118 +11,115 @@ use chiquito::{
     },
     ir::{assigments::AssigmentGenerator, Circuit}, // compiled circuit type
 };
-use halo2curves::{ff::Field, bn256::Fr};
+use halo2_proofs::dev::MockProver;
+use halo2curves::{bn256::Fr, ff::Field};
+use std::{cell::RefCell, hash::Hash, rc::Rc};
 
 // Generic types:
-// 1) (F, F) are the elements that are in the stack; the stack is made up of two signals with many steps so each basic operation consumes 1 step
-// 3) F for the result of the operation
-fn forth_circuit<F: Field + From<u64>>() -> (Circuit<F>, Option<AssigmentGenerator<F, ()>>) {
+// (F, F, F) are the elements that are in the stack along with the result of the operation
+fn forth_circuit<F: Field + From<u64> + Hash>() -> (Circuit<F>, Option<AssigmentGenerator<F, ()>>) {
     // PLONKish table for the FORTH stack:
     // | s1 | s2  | r |
-    // |  1 |  1  | 2 |
-    // |  3 |  2  | 6 |
-    // |  4 |  2  | 2 |
+    // |  1 |  1  | 2 | <- where step type is add
+    // |  3 |  2  | 6 | <- where step type is mul
+    // |  4 |  2  | 2 | <- where step type is sub
 
-    let forth = circuit::<(F, F), F>("FORTH", |ctx| {
-
+    let forth = circuit::<F, (), (F, F, F), _>("FORTH", |ctx| {
         // declare signals
-        let s1 = ctx.forward("s1");
-        let s2 = ctx.forward("s2");
-        let r = ctx.forward("r");
+        let s1 = Rc::new(RefCell::new(ctx.forward("s1")));
+        let s2 = Rc::new(RefCell::new(ctx.forward("s2")));
+        let r = Rc::new(RefCell::new(ctx.forward("r")));
 
-        // initialize steps
-        let add_step = ctx.step_type("add");
-        let sub_step = ctx.step_type("sub");
-        let mul_step = ctx.step_type("mul");
-        let div_step = ctx.step_type("div");
+        ctx.pragma_num_steps(3);
 
-        // first step type: Since it's a general VM, do we need an ordering to the steps?
-        ctx.pragma_first_step(add_step);
-        // last step type
-        ctx.pragma_last_step(div_step);
-        // total number of steps: Should this be arbitrary?
-        ctx.pragma_num_steps(4);
-
-        // addition operation step
         let add_step = ctx.step_type_def("add", |ctx| {
+            let s1_cloned = s1.clone();
+            let s2_cloned = s2.clone();
+            let r_cloned = r.clone();
+
             ctx.setup(move |ctx| {
-                ctx.constr(eq(s1 + s2, r));
+                ctx.constr(eq(
+                    *s1_cloned.borrow() + *s2_cloned.borrow(),
+                    *r_cloned.borrow(),
+                ));
             });
 
+            let s1_cloned = s1.clone();
+            let s2_cloned = s2.clone();
+            let r_cloned = r.clone();
+
             ctx.wg(move |ctx, (s1_value, s2_value, r_value): (F, F, F)| {
-                println!("add step: s1: {}, s2: {}, r: {}", s1_value, s2_value, r_value);
-                ctx.assign(s1, s1_value);
-                ctx.assign(s2, s2_value);
-                ctx.assign(r, r_value);
+                ctx.assign(*s1_cloned.borrow(), s1_value);
+                ctx.assign(*s2_cloned.borrow(), s2_value);
+                ctx.assign(*r_cloned.borrow(), r_value);
             })
         });
 
-        // subtraction operation step
         let sub_step = ctx.step_type_def("sub", |ctx| {
+            let s1_cloned = s1.clone();
+            let s2_cloned = s2.clone();
+            let r_cloned = r.clone();
+
             ctx.setup(move |ctx| {
-                ctx.constr(eq(s1 - s2, r));
+                ctx.constr(eq(
+                    *s1_cloned.borrow() - *s2_cloned.borrow(),
+                    *r_cloned.borrow(),
+                ));
             });
+
+            let s1_cloned = s1.clone();
+            let s2_cloned = s2.clone();
+            let r_cloned = r.clone();
 
             ctx.wg(move |ctx, (s1_value, s2_value, r_value): (F, F, F)| {
-                println!("sub step: s1: {}, s2: {}, r: {}", s1_value, s2_value, r_value);
-                ctx.assign(s1, s1_value);
-                ctx.assign(s2, s2_value);
-                ctx.assign(r, r_value);
+                ctx.assign(*s1_cloned.borrow(), s1_value);
+                ctx.assign(*s2_cloned.borrow(), s2_value);
+                ctx.assign(*r_cloned.borrow(), r_value);
             })
         });
 
-        // multiplication operation step
         let mul_step = ctx.step_type_def("mul", |ctx| {
+            let s1_cloned = s1.clone();
+            let s2_cloned = s2.clone();
+            let r_cloned = r.clone();
+
             ctx.setup(move |ctx| {
-                ctx.constr(eq(s1 * s2, r));
+                ctx.constr(eq(
+                    *s1_cloned.borrow() * *s2_cloned.borrow(),
+                    *r_cloned.borrow(),
+                ));
             });
 
-            ctx.wg(|ctx, (s1_result, s2_result, r_result): (F, F, F)| {
-                println!("mul step: s1: {}, s2: {}, r: {}", s1_result, s2_result, r_result);
-                ctx.assign(s1, s1_result);
-                ctx.assign(s2, s2_result);
-                ctx.assign(r, r_result);
-            })
-        });
+            let s1_cloned = s1.clone();
+            let s2_cloned = s2.clone();
+            let r_cloned = r.clone();
 
-        // division operation step
-        let div_step = ctx.step_type_def("div", |ctx| {
-            ctx.setup(move |ctx| {
-                ctx.constr(eq(s1 / s2, r));
-            });
-
-            ctx.wg(|ctx, (s1_result, s2_result, r_result): (F, F, F)| {
-                println!("div step: s1: {}, s2: {}, r: {}", s1_result, s2_result, r_result);
-                ctx.assign(s1, s1_result);
-                ctx.assign(s2, s2_result);
-                ctx.assign(r, r_result);
+            ctx.wg(move |ctx, (s1_value, s2_value, r_value): (F, F, F)| {
+                ctx.assign(*s1_cloned.borrow(), s1_value);
+                ctx.assign(*s2_cloned.borrow(), s2_value);
+                ctx.assign(*r_cloned.borrow(), r_value);
             })
         });
 
         ctx.trace(move |ctx: _, _| {
-            // Here we fill the circuit with the constraint 1 + 1 = 2
-            ctx.add(&add_step, (1, 1, 2));
+            // 1 + 1 = 2
+            ctx.add(&add_step, (F::from(1u64), F::from(1u64), F::from(2u64)));
             // 5 - 4 = 1
-            ctx.add(&sub_step, (5, 4, 1));
+            ctx.add(&sub_step, (F::from(5u64), F::from(4u64), F::from(1u64)));
             // 2 * 3 = 6
-            ctx.add(&mul_step, (2, 3, 6));
-            // 4 / 2 = 2
-            ctx.add(&div_step, (4, 2, 2));
+            ctx.add(&mul_step, (F::from(2u64), F::from(3u64), F::from(6u64)));
         });
     });
 
     let compiler = Compiler::new(SingleRowCellManager {}, SimpleStepSelectorBuilder {});
 
     compiler.compile(&forth)
-
 }
 
 fn main() {
     let (chiquito, wit_gen) = forth_circuit::<Fr>();
     let compiled = chiquito2Halo2(chiquito);
-    // passing 0 as the TraceArgs argument for g.generate as somewhat of a placeholder since TraceArgs aren't used in this example
-    let circuit = ChiquitoHalo2Circuit::new(compiled, wit_gen.map(|g| g.generate(0)));
-    println!("Compiled circuit: {:?}", circuit);
+    let circuit = ChiquitoHalo2Circuit::new(compiled, wit_gen.map(|g| g.generate(())));
 
     let prover = MockProver::<Fr>::run(7, &circuit, Vec::new()).unwrap();
 

--- a/examples/forth.rs
+++ b/examples/forth.rs
@@ -1,0 +1,36 @@
+use chiquito::{
+    ast::expr::*,
+    backend::halo2::{chiquito2Halo2, ChiquitoHalo2Circuit}, /* compiles to
+                                                             * Chiquito Halo2
+                                                             * backend,
+                                                             * which can be
+                                                             * integrated into
+                                                             * Halo2
+                                                             * circuit */
+    compiler::{
+        cell_manager::SingleRowCellManager, // input for constructing the compiler
+        step_selector::SimpleStepSelectorBuilder, // input for constructing the compiler
+        Compiler,
+    },
+    dsl::{
+        cb::*,   // functions for constraint building
+        circuit, // main function for constructing an AST circuit
+    },
+    ir::{assigments::AssigmentGenerator, Circuit}, // compiled circuit type
+};
+use halo2curves::ff::Field;
+
+// Generic types:
+// 1) F for a type that implements the field element trait
+// 2) (u64, u64) are the elements that are in the stack; the stack is made up of two signals with many steps so each basic operation consumes 1 step
+// 3) u8 for the operation; we will map 1 -> +, 2 -> -, 3 -> *, 4 -> /
+// 4) u64 for the result of the operation
+fn forth_circuit<F: Field + From<u64>>() -> (Circuit<F>, Option<AssigmentGenerator<F, ()>>) {
+    // PLONKish table for the FORTH stack:
+    // | s1 | s2 | o | r |
+    // |  1 |  1 | 1 | 2 |
+    // |  3 |  2 | 3 | 6 |
+    // |  4 |  2 | 4 | 2 |
+
+    
+}

--- a/examples/forth.rs
+++ b/examples/forth.rs
@@ -49,7 +49,26 @@ fn forth_circuit<F: Field + From<u64>>() -> (Circuit<F>, Option<AssigmentGenerat
 
         // stack operation step
         let stack_step = ctx.step_type_def("stack step", |ctx| {
-            
+            ctx.setup(move |ctx| {
+                // are matches allowed in circuit definitions?
+                match o {
+                    1 => {
+                        ctx.constr(eq(s1 + s2, c));
+                    }
+                    2 => {
+                        ctx.constr(eq(s1 - s2, c));
+                    }
+                    3 => {
+                        ctx.constr(eq(s1 * s2, c));
+                    }
+                    4 => {
+                        ctx.constr(eq(s1 / s2, c));
+                    }
+                    _ => {
+                        panic!("invalid operation")
+                    }
+                }
+            });
         });
     });
 }


### PR DESCRIPTION
DRAFT: This is a limited implementation of a circuit for the [FORTH](https://en.wikipedia.org/wiki/Forth_(programming_language)) stack-based programming language. 
- this circuit has different step types for the various operations on a FORTH machine (it doesn't support division due to the limitations of the finite field; this should perhaps be implemented with a lookup table or other strategies). 
- It does not implement the `plaf` boilerplate (let me know if this should be included)

Future tasks:
- Implement division
- Implement other features like mod, bit shift
- Change the input from individual numbers to actual stack elements, then to programs/binaries that can prove each stack iteration (perhaps use folding to prove larger programs)