### PR TITLE
Keep `witness` argument immutable on `halo2_mock_prover`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chiquito"
-version = "0.1.2023110200"
+version = "0.1.2023110700"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Leo Lara <leo@leolara.me>"]

--- a/src/frontend/python/chiquito/dsl.py
+++ b/src/frontend/python/chiquito/dsl.py
@@ -73,15 +73,15 @@ class SuperCircuit:
     def halo2_mock_prover(
         self: SuperCircuit, super_witness: Dict[int, TraceWitness], k: int = 16
     ):
+        witness_json = {}
         for rust_id, witness in super_witness.items():
             if rust_id not in self.ast.sub_circuits:
                 raise ValueError(
                     f"SuperCircuit.halo2_mock_prover(): TraceWitness with rust_id {rust_id} not found in sub_circuits."
                 )
-            witness_json: str = witness.get_witness_json()
-            super_witness[rust_id] = witness_json
+            witness_json[rust_id] = witness.get_witness_json()
         rust_chiquito.super_circuit_halo2_mock_prover(
-            list(self.ast.sub_circuits.keys()), super_witness, k
+            list(self.ast.sub_circuits.keys()), witness_json, k
         )
 
 


### PR DESCRIPTION
Closes #170 

---

On the SuperCircuit's `halo2_mock_prover` method, we are currently overriding the `super_witness` dict object.
Initially it holds the `TraceWitness` objects of each internal circuit, but after the loop it holds the JSON representation of the witness of the circuit.

Since the elements in the dict are indexed by their `rust_id`, after the loop all the elements have been replaced, leaving the caller of `halo2_mock_prover` with a "modified" `witness`.

It's not a big problem, but it's confusing sometimes when writing tests, if you want to verify some of the assignments, because the order of lines becomes relevant.

I didn't add the return of the `witness_json` because so far I've seen no use for it. Maybe it could be interesting.