### PR TITLE
Add optional keyword arguments to `SuperCircuit`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chiquito"
-version = "0.1.2023110700"
+version = "0.1.2023110800"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Leo Lara <leo@leolara.me>"]

--- a/src/frontend/python/chiquito/dsl.py
+++ b/src/frontend/python/chiquito/dsl.py
@@ -29,8 +29,8 @@ class SuperCircuitMode(Enum):
 
 class SuperCircuit:
     def __init__(
-            self: SuperCircuit,
-            **kwargs,  # **kwargs is intended for arbitrary names for imports
+        self: SuperCircuit,
+        **kwargs,  # **kwargs is intended for arbitrary names for imports
     ):
         for key, value in kwargs.items():
             setattr(self, key, value)
@@ -76,7 +76,7 @@ class SuperCircuit:
         return super_witness
 
     def halo2_mock_prover(
-            self: SuperCircuit, super_witness: Dict[int, TraceWitness], k: int = 16
+        self: SuperCircuit, super_witness: Dict[int, TraceWitness], k: int = 16
     ):
         witness_json = {}
         for rust_id, witness in super_witness.items():
@@ -99,9 +99,9 @@ class CircuitMode(Enum):
 
 class Circuit:
     def __init__(
-            self: Circuit,
-            super_circuit: SuperCircuit = None,
-            **kwargs,  # **kwargs is intended for arbitrary names for imports
+        self: Circuit,
+        super_circuit: SuperCircuit = None,
+        **kwargs,  # **kwargs is intended for arbitrary names for imports
     ):
         self.ast = ASTCircuit()
         self.witness = TraceWitness()

--- a/src/frontend/python/chiquito/dsl.py
+++ b/src/frontend/python/chiquito/dsl.py
@@ -28,7 +28,12 @@ class SuperCircuitMode(Enum):
 
 
 class SuperCircuit:
-    def __init__(self: SuperCircuit):
+    def __init__(
+            self: SuperCircuit,
+            **kwargs,  # **kwargs is intended for arbitrary names for imports
+    ):
+        for key, value in kwargs.items():
+            setattr(self, key, value)
         self.ast = ASTSuperCircuit()
         self.mode = SuperCircuitMode.SETUP
         self.setup()
@@ -71,7 +76,7 @@ class SuperCircuit:
         return super_witness
 
     def halo2_mock_prover(
-        self: SuperCircuit, super_witness: Dict[int, TraceWitness], k: int = 16
+            self: SuperCircuit, super_witness: Dict[int, TraceWitness], k: int = 16
     ):
         witness_json = {}
         for rust_id, witness in super_witness.items():
@@ -94,9 +99,9 @@ class CircuitMode(Enum):
 
 class Circuit:
     def __init__(
-        self: Circuit,
-        super_circuit: SuperCircuit = None,
-        **kwargs,  # **kwargs is intended for arbitrary names for imports
+            self: Circuit,
+            super_circuit: SuperCircuit = None,
+            **kwargs,  # **kwargs is intended for arbitrary names for imports
     ):
         self.ast = ASTCircuit()
         self.witness = TraceWitness()


### PR DESCRIPTION
In some cases, we need to pass information into the Circuit/SuperCircuit, and for that, we can use optional keyword arguments sent through the constructor.

This PR adds this feature, already present in `Circuit`, into `SuperCircuit`.