### PR TITLE
Track compilation phase on CompilationUnit

### DIFF
--- a/src/plonkish/compiler/unit.rs
+++ b/src/plonkish/compiler/unit.rs
@@ -49,7 +49,7 @@ pub struct CompilationUnit<F> {
     pub other_sub_circuits: Rc<Vec<CompilationUnit<F>>>,
     pub other_columns: Rc<Vec<Column>>,
 
-    pub compilation_phase: usize,
+    pub compilation_phase: u32,
 }
 
 impl<F> Default for CompilationUnit<F> {

--- a/src/plonkish/compiler/unit.rs
+++ b/src/plonkish/compiler/unit.rs
@@ -48,6 +48,8 @@ pub struct CompilationUnit<F> {
 
     pub other_sub_circuits: Rc<Vec<CompilationUnit<F>>>,
     pub other_columns: Rc<Vec<Column>>,
+
+    pub compilation_phase: usize,
 }
 
 impl<F> Default for CompilationUnit<F> {
@@ -82,6 +84,8 @@ impl<F> Default for CompilationUnit<F> {
 
             other_sub_circuits: Default::default(),
             other_columns: Default::default(),
+
+            compilation_phase: Default::default(),
         }
     }
 }


### PR DESCRIPTION
**Issue:** #192 
It adds a field on the CompilationUnit struct to store the phase of compilation, and panics if we try to run `compile_phase2` without phase1 being done before.