### PR TITLE
215 add variable assignment operator to parser

### DIFF
--- a/src/compiler/abepi.rs
+++ b/src/compiler/abepi.rs
@@ -36,7 +36,7 @@ impl<F: From<u64> + Into<u32> + Clone, V: Clone> CompilationUnit<F, V> {
     pub fn compile_statement(&self, source: Statement<F, V>) -> Vec<CompilationResult<F, V>> {
         match source {
             Statement::Assert(_, expr) => vec![self.compile_expression(expr)],
-            Statement::AssignmentAssert(dsym, lhs, rhs) => {
+            Statement::SignalAssignmentAssert(dsym, lhs, rhs) => {
                 assert_eq!(lhs.len(), rhs.len());
 
                 lhs.iter()

--- a/src/compiler/semantic/analyser.rs
+++ b/src/compiler/semantic/analyser.rs
@@ -226,10 +226,13 @@ impl Analyser {
     fn analyse_statement_recursive(&mut self, stmt: Statement<BigInt, Identifier>) {
         match stmt {
             Statement::Assert(_, expr) => self.analyse_expression(expr),
-            Statement::Assignment(_, _, exprs) => exprs
+            Statement::SignalAssignment(_, _, exprs) => exprs
                 .into_iter()
                 .for_each(|expr| self.analyse_expression(expr)),
-            Statement::AssignmentAssert(_, _, exprs) => exprs
+            Statement::SignalAssignmentAssert(_, _, exprs) => exprs
+                .into_iter()
+                .for_each(|expr| self.analyse_expression(expr)),
+            Statement::WGAssignment(_, _, exprs) => exprs
                 .into_iter()
                 .for_each(|expr| self.analyse_expression(expr)),
             Statement::IfThen(_, cond, when_true) => {

--- a/src/compiler/semantic/rules.rs
+++ b/src/compiler/semantic/rules.rs
@@ -104,8 +104,8 @@ fn state_decl(analyser: &mut Analyser, expr: &Statement<BigInt, Identifier>) {
 // Should only allow to assign or assign and assert signals (and not wg vars).
 fn assignment_rule(analyser: &mut Analyser, expr: &Statement<BigInt, Identifier>) {
     let ids = match expr {
-        Statement::Assignment(_, id, _) => id,
-        Statement::AssignmentAssert(_, id, _) => id,
+        Statement::SignalAssignment(_, id, _) => id,
+        Statement::SignalAssignmentAssert(_, id, _) => id,
         _ => return,
     };
 

--- a/src/parser/ast/statement.rs
+++ b/src/parser/ast/statement.rs
@@ -13,35 +13,37 @@ pub struct TypedIdDecl<V> {
 
 #[derive(Clone)]
 pub enum Statement<F, V> {
-    Assert(DebugSymRef, Expression<F, V>),
+    Assert(DebugSymRef, Expression<F, V>), // assert x;
 
-    Assignment(DebugSymRef, Vec<V>, Vec<Expression<F, V>>),
-    AssignmentAssert(DebugSymRef, Vec<V>, Vec<Expression<F, V>>),
+    SignalAssignment(DebugSymRef, Vec<V>, Vec<Expression<F, V>>), // x <-- y;
+    SignalAssignmentAssert(DebugSymRef, Vec<V>, Vec<Expression<F, V>>), // x <== y;
+    WGAssignment(DebugSymRef, Vec<V>, Vec<Expression<F, V>>),     // x = y;
 
-    IfThen(DebugSymRef, Box<Expression<F, V>>, Box<Statement<F, V>>),
+    IfThen(DebugSymRef, Box<Expression<F, V>>, Box<Statement<F, V>>), // if x { y }
     IfThenElse(
         DebugSymRef,
         Box<Expression<F, V>>,
         Box<Statement<F, V>>,
         Box<Statement<F, V>>,
-    ),
+    ), // if x { y } else { z }
 
-    SignalDecl(DebugSymRef, Vec<TypedIdDecl<V>>),
-    WGVarDecl(DebugSymRef, Vec<TypedIdDecl<V>>),
+    SignalDecl(DebugSymRef, Vec<TypedIdDecl<V>>), // signal x;
+    WGVarDecl(DebugSymRef, Vec<TypedIdDecl<V>>),  // var x;
 
-    StateDecl(DebugSymRef, V, Box<Statement<F, V>>),
+    StateDecl(DebugSymRef, V, Box<Statement<F, V>>), // state x { y }
 
-    Transition(DebugSymRef, V, Box<Statement<F, V>>),
+    Transition(DebugSymRef, V, Box<Statement<F, V>>), // -> x { y }
 
-    Block(DebugSymRef, Vec<Statement<F, V>>),
+    Block(DebugSymRef, Vec<Statement<F, V>>), // { x }
 }
 
 impl<F: Debug> Debug for Statement<F, Identifier> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Assert(_, arg0) => write!(f, "assert {:?};", arg0),
-            Self::Assignment(_, arg0, arg1) => write!(f, "{:?} <-- {:?};", arg0, arg1),
-            Self::AssignmentAssert(_, arg0, arg1) => write!(f, "{:?} <== {:?};", arg0, arg1),
+            Self::SignalAssignment(_, arg0, arg1) => write!(f, "{:?} <-- {:?};", arg0, arg1),
+            Self::SignalAssignmentAssert(_, arg0, arg1) => write!(f, "{:?} <== {:?};", arg0, arg1),
+            Self::WGAssignment(_, arg0, arg1) => write!(f, "{:?} = {:?};", arg0, arg1),
             Statement::IfThen(_, arg0, arg1) => {
                 write!(f, "if {:?} {:?}", arg0, arg1)
             }
@@ -90,8 +92,9 @@ impl<F, V> Statement<F, V> {
     pub fn get_dsym(&self) -> DebugSymRef {
         match self {
             Statement::Assert(dsym, _) => dsym.clone(),
-            Statement::Assignment(dsym, _, _) => dsym.clone(),
-            Statement::AssignmentAssert(dsym, _, _) => dsym.clone(),
+            Statement::SignalAssignment(dsym, _, _) => dsym.clone(),
+            Statement::SignalAssignmentAssert(dsym, _, _) => dsym.clone(),
+            Statement::WGAssignment(dsym, _, _) => dsym.clone(),
             Statement::IfThen(dsym, _, _) => dsym.clone(),
             Statement::IfThenElse(dsym, _, _, _) => dsym.clone(),
             Statement::SignalDecl(dsym, _) => dsym.clone(),

--- a/src/parser/chiquito.lalrpop
+++ b/src/parser/chiquito.lalrpop
@@ -40,9 +40,10 @@ ParseStatement: Statement<BigInt, Identifier> = {
     <s: AssertEq> ";" => s,
     <s: AssertNEq> ";" => s,
     <s: Assert> ";" => s,
-    <a: AssignmentAssert> ";" => a,
+    <a: SignalAssignmentAssert> ";" => a,
     
-    <a: Assignment> ";" => a,
+    <a: SignalAssignment> ";" => a,
+    <a: WGAssignment> ";" => a,
 
     <v: ParseSignalDecl> ";" => v,
     <v: ParseWGVarDecl> ";" => v,
@@ -69,12 +70,16 @@ Assert: Statement<BigInt, Identifier> = {
 }
 
 // Basic statements
-Assignment: Statement<BigInt, Identifier> = {
-    <ids: ParseIdsList> "<--" <es:ParseExpressionList> => Statement::Assignment(DebugSymRef::new(0,0), ids, es),
+SignalAssignment: Statement<BigInt, Identifier> = {
+    <ids: ParseIdsList> "<--" <es:ParseExpressionList> => Statement::SignalAssignment(DebugSymRef::new(0,0), ids, es),
 }
 
-AssignmentAssert: Statement<BigInt, Identifier> = {
-    <ids: ParseIdsList> "<==" <es:ParseExpressionList> => Statement::AssignmentAssert(DebugSymRef::new(0,0), ids, es),
+SignalAssignmentAssert: Statement<BigInt, Identifier> = {
+    <ids: ParseIdsList> "<==" <es:ParseExpressionList> => Statement::SignalAssignmentAssert(DebugSymRef::new(0,0), ids, es),
+}
+
+WGAssignment: Statement<BigInt, Identifier> = {
+    <ids: ParseIdsList> "=" <es:ParseExpressionList> => Statement::WGAssignment(DebugSymRef::new(0,0), ids, es),
 }
 
 ParseIf: Statement<BigInt, Identifier> = {


### PR DESCRIPTION
Renamed current `Assignment` and `AssignmentAssert` to `SignalAssignment` and `SignalAssignmentAssert` and implemented `WGAssignment` to assign vars.