### PR TITLE
Rutefig/221 semantic analyser cannot redeclare a variable wg signal in the same scope

### DIFF
--- a/src/compiler/semantic/rules.rs
+++ b/src/compiler/semantic/rules.rs
@@ -195,7 +195,7 @@ fn check_expr_for_wgvar(
     }
 }
 
-// Cannot redeclare a variable (wgvar or signal) in the same scope.
+// Cannot redeclare a variable (wgvar, signal) or state in the same scope.
 fn redeclare_rule(
     analyser: &mut Analyser,
     expr: &Statement<BigInt, Identifier>,

--- a/src/compiler/semantic/rules.rs
+++ b/src/compiler/semantic/rules.rs
@@ -687,6 +687,12 @@ mod test {
             signal n; // cannot redeclare n
 
             state middle {
+                -> final {
+                    i', n' <== i + 1, n;
+                }
+            }
+
+            state middle {
              signal c;
              signal c; // cannot redeclare c
 
@@ -716,7 +722,7 @@ mod test {
 
         assert_eq!(
             format!("{:?}", result.messages),
-            r#"[Err { msg: "Cannot redeclare n in the same scope [\"/\", \"fibo\"]", dsym: DebugSymRef { start: 0, end: 0 } }, Err { msg: "Cannot redeclare c in the same scope [\"/\", \"fibo\", \"middle\"]", dsym: DebugSymRef { start: 0, end: 0 } }]"#
+            r#"[Err { msg: "Cannot redeclare middle in the same scope [\"/\", \"fibo\"]", dsym: DebugSymRef { start: 0, end: 0 } }, Err { msg: "Cannot redeclare n in the same scope [\"/\", \"fibo\"]", dsym: DebugSymRef { start: 0, end: 0 } }, Err { msg: "Cannot redeclare c in the same scope [\"/\", \"fibo\", \"middle\"]", dsym: DebugSymRef { start: 0, end: 0 } }]"#
         );
     }
 }

--- a/src/compiler/semantic/rules.rs
+++ b/src/compiler/semantic/rules.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Debug, vec};
+use std::vec;
 
 use lazy_static::lazy_static;
 
@@ -195,12 +195,31 @@ fn check_expr_for_wgvar(
     }
 }
 
+// Cannot redeclare a variable (wgvar or signal) in the same scope.
+fn redeclare_rule(
+    analyser: &mut Analyser,
+    expr: &Statement<BigInt, Identifier>,
+    id: &Identifier,
+    _symbol: &SymTableEntry,
+) {
+    if let Some(_) = analyser.symbols.find_symbol(&analyser.cur_scope, id.name()) {
+        analyser.error(
+            format!(
+                "Cannot redeclare {} in the same scope {:?}",
+                id.name(),
+                analyser.cur_scope
+            ),
+            &expr.get_dsym(),
+        )
+    }
+}
+
 lazy_static! {
     /// Global semantic analyser rules.
     pub(super) static ref RULES: RuleSet = RuleSet {
         expression: vec![undeclared_rule],
         statement: vec![state_decl, assignment_rule, assert_rule],
-        new_symbol: vec![rotation_decl],
+        new_symbol: vec![rotation_decl, redeclare_rule],
         new_tl_symbol: vec![rotation_decl_tl],
     };
 }
@@ -642,5 +661,62 @@ mod test {
             format!("{:?}", result.messages),
             r#"[Err { msg: "Cannot use wgvar wrong in statement assert wrong == 3;", dsym: DebugSymRef { start: 0, end: 0 } }, Err { msg: "Cannot use wgvar wrong in statement [c] <== [(a + b) + wrong];", dsym: DebugSymRef { start: 0, end: 0 } }]"#
         )
+    }
+
+    #[test]
+    fn test_redeclare_rule() {
+        let circuit = "
+        machine fibo(signal n) (signal b: field) {
+            // n and be are created automatically as shared
+            // signals
+            signal a: field, i;
+
+            // there is always a state called initial
+            // input signals get binded to the signal
+            // in the initial state (first instance)
+            state initial {
+             signal c;
+
+             i, a, b, c <== 1, 1, 1, 2;
+
+             -> middle {
+              a', b', n' <== b, c, n;
+             }
+            }
+
+            signal n; // cannot redeclare n
+
+            state middle {
+             signal c;
+             signal c; // cannot redeclare c
+
+             c <== a + b;
+
+             if i + 1 == n {
+              -> final {
+               i', b', n' <== i + 1, c, n;
+              }
+             } else {
+              -> middle {
+               i', a', b', n' <== i + 1, b, c, n;
+              }
+             }
+            }
+
+            // There is always a state called final.
+            // Output signals get automatically bindinded to the signals
+            // with the same name in the final step (last instance).
+            // This state can be implicit if there are no constraints in it.
+           }
+        ";
+
+        let decls = lang::TLDeclsParser::new().parse(circuit).unwrap();
+
+        let result = analyse(decls);
+
+        assert_eq!(
+            format!("{:?}", result.messages),
+            r#"[Err { msg: "Cannot redeclare n in the same scope [\"/\", \"fibo\"]", dsym: DebugSymRef { start: 0, end: 0 } }, Err { msg: "Cannot redeclare c in the same scope [\"/\", \"fibo\", \"middle\"]", dsym: DebugSymRef { start: 0, end: 0 } }]"#
+        );
     }
 }


### PR DESCRIPTION
I wanted to do some discussion here, so I implemented this rule to actually check for every new symbol that is created if there is another one with the same identifier name, which means that right now is also covering state. Do you think we should allow to redeclare a new state with the same id?

Another think I was thinking in the meantime is if we should allow the dev to do something like this:
```
// declaring a state with the same id as a var
machine a()() {
  signal b;
  
  state b { 
     b' <== b;
   }
 }
 ```