### PR TITLE
Rutefig/237 fix python front end

### DIFF
--- a/src/frontend/dsl/mod.rs
+++ b/src/frontend/dsl/mod.rs
@@ -600,15 +600,12 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     #[should_panic(expected = "Signal not found")]
     fn test_expose_non_existing_signal() {
         let mut context = setup_circuit_context::<i32, i32>();
         let non_existing_signal =
             Queriable::Forward(ForwardSignal::new_with_phase(0, "".to_owned()), false); // Create a signal not added to the circuit
         context.expose(non_existing_signal, ExposeOffset::First);
-
-        todo!("remove the ignore after fixing the check for non existing signals")
     }
 
     #[test]

--- a/src/frontend/python/chiquito/cb.py
+++ b/src/frontend/python/chiquito/cb.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass, field
 from enum import Enum, auto
-from typing import List, Dict, Optional
+from typing import List, Dict, Optional, Union
 
 from chiquito.util import F, uuid
 from chiquito.expr import Expr, Const, Neg, to_expr, ToExpr
@@ -205,7 +205,7 @@ def table() -> LookupTable:
     return LookupTable()
 
 
-ToConstraint = Constraint | Expr | int | F
+ToConstraint = Union[Constraint, Expr, int, F]
 
 
 def to_constraint(v: ToConstraint) -> Constraint:

--- a/src/frontend/python/chiquito/chiquito_ast.py
+++ b/src/frontend/python/chiquito/chiquito_ast.py
@@ -126,7 +126,7 @@ class ASTCircuit:
             "last_step": self.last_step,
             "num_steps": self.num_steps,
             "q_enable": self.q_enable,
-            "id": self.id,
+            "id": self.id.__str__(),
         }
 
     def add_forward(self: ASTCircuit, name: str, phase: int) -> ForwardSignal:

--- a/src/frontend/python/chiquito/dsl.py
+++ b/src/frontend/python/chiquito/dsl.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import List, Dict
+from typing import List, Dict, Union
 from enum import Enum
 from typing import Callable, Any
 
@@ -295,4 +295,4 @@ class StepType:
         self.step_type.lookups.append(lookup)
 
 
-LookupBuilder = LookupTableBuilder | InPlaceLookupBuilder
+LookupBuilder = Union[LookupTableBuilder, InPlaceLookupBuilder]

--- a/src/frontend/python/chiquito/expr.py
+++ b/src/frontend/python/chiquito/expr.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import List
+from typing import List, Union
 from dataclasses import dataclass
 
 from chiquito.util import F
@@ -141,7 +141,7 @@ class Pow(Expr):
         return {"Pow": [self.expr.__json__(), self.pow]}
 
 
-ToExpr = Expr | int | F
+ToExpr = Union[Expr, int, F]
 
 
 def to_expr(v: ToExpr) -> Expr:

--- a/src/frontend/python/chiquito/query.py
+++ b/src/frontend/python/chiquito/query.py
@@ -134,5 +134,5 @@ class StepTypeNext(Queriable):
 
     def __json__(self):
         return {
-            "StepTypeNext": {"id": self.step_type.id, "annotation": self.step_type.name}
+            "StepTypeNext": {"id": f"{self.step_type.id}", "annotation": self.step_type.name}
         }

--- a/src/frontend/python/chiquito/util.py
+++ b/src/frontend/python/chiquito/util.py
@@ -14,11 +14,9 @@ class F(bn128.FQ):
         # Convert the integer to a byte array
         montgomery_form = self.n * R % F.field_modulus
         byte_array = montgomery_form.to_bytes(32, "little")
-        # Split into four 64-bit integers
-        ints = [
-            int.from_bytes(byte_array[i * 8 : i * 8 + 8], "little") for i in range(4)
-        ]
-        return ints
+        
+        # return the hex string
+        return byte_array.hex()
 
 
 class CustomEncoder(json.JSONEncoder):

--- a/src/frontend/python/chiquito/util.py
+++ b/src/frontend/python/chiquito/util.py
@@ -29,5 +29,5 @@ class CustomEncoder(json.JSONEncoder):
 
 
 # int field is the u128 version of uuid.
-def uuid() -> int:
-    return uuid1(node=int.from_bytes([10, 10, 10, 10, 10, 10], byteorder="little")).int
+def uuid() -> str:
+    return uuid1(node=int.from_bytes([10, 10, 10, 10, 10, 10], byteorder="little")).int.__str__()

--- a/src/frontend/python/chiquito/wit_gen.py
+++ b/src/frontend/python/chiquito/wit_gen.py
@@ -41,7 +41,7 @@ class StepInstance:
     # For assignments, return "uuid: (Queriable, F)" rather than "Queriable: F", because JSON doesn't accept Dict as key.
     def __json__(self: StepInstance):
         return {
-            "step_type_uuid": self.step_type_uuid,
+            "step_type_uuid": self.step_type_uuid.__str__(),
             "assignments": {
                 lhs.uuid(): [lhs, rhs] for (lhs, rhs) in self.assignments.items()
             },

--- a/src/frontend/python/mod.rs
+++ b/src/frontend/python/mod.rs
@@ -920,7 +920,6 @@ impl<'de> Deserialize<'de> for SBPIR<Fr, ()> {
 mod tests {
     use super::*;
 
-    #[ignore]
     #[test]
     fn test_trace_witness() {
         let json = r#"
@@ -1065,7 +1064,6 @@ mod tests {
         let _: ExposeOffset = serde_json::from_str(json).unwrap();
     }
 
-    #[ignore]
     #[test]
     fn test_circuit() {
         let json = r#"
@@ -1537,7 +1535,6 @@ mod tests {
         println!("{:?}", circuit);
     }
 
-    #[ignore]
     #[test]
     fn test_step_type() {
         let json = r#"
@@ -1673,7 +1670,6 @@ mod tests {
         println!("{:?}", step_type);
     }
 
-    #[ignore]
     #[test]
     fn test_constraint() {
         let json = r#"
@@ -1757,7 +1753,6 @@ mod tests {
         println!("{:?}", transition_constraint);
     }
 
-    #[ignore]
     #[test]
     fn test_expr() {
         let json = r#"

--- a/src/frontend/python/mod.rs
+++ b/src/frontend/python/mod.rs
@@ -969,6 +969,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[ignore]
     fn test_trace_witness() {
         let json = r#"
         {


### PR DESCRIPTION
- Fixed Python json object: 
   - ids as strings instead of large integers which were being interpreted as floating numbers
   - Fr as hex string to match the new version of deserialization of `halo2curves`: https://github.com/privacy-scaling-explorations/halo2curves/commit/8e3a33af78c941bb87ab8a5e81dc4cb3d09c0d69
- Fixed deserialization to deal with required changes from updating libraries and fixed tests to match expected json structures