### PR TITLE
Rutefig/cse hash expressions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,8 +33,6 @@ lalrpop-util = { version = "0.20.0", features = ["lexer", "unicode"] }
 lazy_static = "1.4.0"
 itertools = "0.12.1"
 codespan-reporting = "0.11.1"
-
-[dev-dependencies]
 rand_chacha = "0.3"
 
 [build-dependencies]

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -522,7 +522,7 @@ mod test {
            }
         ";
 
-        let debug_sym_ref_factory = DebugSymRefFactory::new("", &circuit);
+        let debug_sym_ref_factory = DebugSymRefFactory::new("", circuit);
         let result = compile::<Fr>(
             circuit,
             Config::default().max_degree(2),

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -195,6 +195,11 @@ impl<F: Field + Hash> Compiler<F> {
         circuit
     }
 
+    #[allow(dead_code)]
+    fn cse(mut _circuit: SBPIR<F, ()>) -> SBPIR<F, ()> {
+        todo!()
+    }
+
     fn translate_queries(
         &mut self,
         symbols: &SymTable,

--- a/src/compiler/semantic/rules.rs
+++ b/src/compiler/semantic/rules.rs
@@ -397,7 +397,7 @@ mod test {
            }
         ";
 
-        let debug_sym_ref_factory = DebugSymRefFactory::new("", &circuit);
+        let debug_sym_ref_factory = DebugSymRefFactory::new("", circuit);
         let decls = lang::TLDeclsParser::new()
             .parse(&debug_sym_ref_factory, circuit)
             .unwrap();
@@ -454,7 +454,7 @@ mod test {
            }
         ";
 
-        let debug_sym_ref_factory = DebugSymRefFactory::new("", &circuit);
+        let debug_sym_ref_factory = DebugSymRefFactory::new("", circuit);
         let decls = lang::TLDeclsParser::new()
             .parse(&debug_sym_ref_factory, circuit)
             .unwrap();
@@ -621,7 +621,7 @@ mod test {
            }
         ";
 
-        let debug_sym_ref_factory = DebugSymRefFactory::new("", &circuit);
+        let debug_sym_ref_factory = DebugSymRefFactory::new("", circuit);
         let decls = lang::TLDeclsParser::new()
             .parse(&debug_sym_ref_factory, circuit)
             .unwrap();
@@ -630,7 +630,7 @@ mod test {
 
         assert_eq!(
             format!("{:?}", result.messages),
-            r#"[SemErr { msg: "Cannot declare state nested here", dsym: DebugSymRef { start: 0, end: 0 } }]"#
+            r#"[SemErr { msg: "Cannot declare state nested here", dsym: DebugSymRef { start: "13:17", end: "15:18" } }]"#
         );
 
         let circuit = "
@@ -687,7 +687,7 @@ mod test {
 
         assert_eq!(
             format!("{:?}", result.messages),
-            r#"[SemErr { msg: "Cannot declare state nested here", dsym: DebugSymRef { start: 0, end: 0 } }]"#
+            r#"[SemErr { msg: "Cannot declare state nested here", dsym: DebugSymRef { start: "18:1", end: "20:29" } }]"#
         );
     }
 
@@ -736,7 +736,7 @@ mod test {
            }
         ";
 
-        let debug_sym_ref_factory = DebugSymRefFactory::new("", &circuit);
+        let debug_sym_ref_factory = DebugSymRefFactory::new("", circuit);
         let decls = lang::TLDeclsParser::new()
             .parse(&debug_sym_ref_factory, circuit)
             .unwrap();
@@ -796,7 +796,7 @@ mod test {
            }
         ";
 
-        let debug_sym_ref_factory = DebugSymRefFactory::new("", &circuit);
+        let debug_sym_ref_factory = DebugSymRefFactory::new("", circuit);
         let decls = lang::TLDeclsParser::new()
             .parse(&debug_sym_ref_factory, circuit)
             .unwrap();
@@ -861,7 +861,7 @@ mod test {
            }
         ";
 
-        let debug_sym_ref_factory = DebugSymRefFactory::new("", &circuit);
+        let debug_sym_ref_factory = DebugSymRefFactory::new("", circuit);
         let decls = lang::TLDeclsParser::new()
             .parse(&debug_sym_ref_factory, circuit)
             .unwrap();
@@ -927,7 +927,7 @@ mod test {
            }
         ";
 
-        let debug_sym_ref_factory = DebugSymRefFactory::new("", &circuit);
+        let debug_sym_ref_factory = DebugSymRefFactory::new("", circuit);
         let decls = lang::TLDeclsParser::new()
             .parse(&debug_sym_ref_factory, circuit)
             .unwrap();
@@ -984,7 +984,7 @@ mod test {
            }
         ";
 
-        let debug_sym_ref_factory = DebugSymRefFactory::new("", &circuit);
+        let debug_sym_ref_factory = DebugSymRefFactory::new("", circuit);
         let decls = lang::TLDeclsParser::new()
             .parse(&debug_sym_ref_factory, circuit)
             .unwrap();
@@ -1050,7 +1050,7 @@ mod test {
            }
         ";
 
-        let debug_sym_ref_factory = DebugSymRefFactory::new("", &circuit);
+        let debug_sym_ref_factory = DebugSymRefFactory::new("", circuit);
         let decls = lang::TLDeclsParser::new()
             .parse(&debug_sym_ref_factory, circuit)
             .unwrap();

--- a/src/field.rs
+++ b/src/field.rs
@@ -5,6 +5,7 @@ use core::{
 };
 
 use num_bigint::BigInt;
+use rand_chacha::rand_core::RngCore;
 
 pub trait Field:
     Sized
@@ -45,6 +46,9 @@ pub trait Field:
     /// return zero if the element is zero. This is different from
     /// FF invert that returns None if the element is zero.
     fn mi(&self) -> Self;
+
+    /// Returns an element chosen uniformly at random using a user-provided RNG.
+    fn random(rng: impl RngCore) -> Self;
 
     /// Exponentiates `self` by `exp`, where `exp` is a little-endian order integer
     /// exponent.

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -156,7 +156,7 @@ mod test {
            }
         ";
 
-        let debug_sym_ref_factory = DebugSymRefFactory::new("", &circuit);
+        let debug_sym_ref_factory = DebugSymRefFactory::new("", circuit);
         let decls = lang::TLDeclsParser::new()
             .parse(&debug_sym_ref_factory, circuit)
             .unwrap();

--- a/src/plonkish/backend/halo2.rs
+++ b/src/plonkish/backend/halo2.rs
@@ -39,6 +39,10 @@ impl<T: PrimeField + From<u64>> ChiquitoField for T {
     fn from_big_int(value: &num_bigint::BigInt) -> Self {
         PrimeField::from_str_vartime(value.to_string().as_str()).expect("field value")
     }
+
+    fn random(rng: impl rand_chacha::rand_core::RngCore) -> Self {
+        Self::random(rng)
+    }
 }
 
 #[allow(non_snake_case)]

--- a/src/poly/cse.rs
+++ b/src/poly/cse.rs
@@ -1,0 +1,83 @@
+use rand_chacha::{rand_core::SeedableRng, ChaCha20Rng};
+
+use crate::field::Field;
+
+use std::{collections::HashSet, fmt::Debug, hash::Hash};
+
+use super::{Expr, HashResult, VarAssignments};
+
+/// Common Subexpression Elimination - takes a collection of expr
+pub fn cse<F: Field + Hash, V: Debug + Clone + Eq + Hash>(
+    exprs: Vec<Expr<F, V, ()>>,
+) -> Vec<Expr<F, V, HashResult>> {
+    // get the key set for the assignments
+    let mut keys: HashSet<V> = HashSet::new();
+
+    for expr in exprs.iter() {
+        // get the assignments for the expression
+        let expr_queries = expr.get_queries();
+        // add the assignments to the key set
+        keys.extend(expr_queries);
+    }
+    // generate random point in the field set
+    let _assignments = generate_random_assignment::<F, V>(keys);
+
+    // hash all the functions using the point for the assignments
+
+    // check if the hash is already in the hash table
+    // if it is, then replace it by a reference to the other one
+
+    // return the expressions hashed and optimized
+
+    todo!()
+}
+
+fn generate_random_assignment<F: Field + Hash, V: Debug + Clone + Eq + Hash>(
+    keys: HashSet<V>,
+) -> VarAssignments<F, V> {
+    let mut rng = ChaCha20Rng::seed_from_u64(0);
+
+    let mut assignments = VarAssignments::new();
+
+    for key in keys.iter() {
+        let value = F::random(&mut rng);
+        assignments.insert(key.clone(), value);
+    }
+
+    assignments
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::collections::HashSet;
+
+    use halo2_proofs::halo2curves::bn256::Fr;
+
+    use crate::sbpir::{query::Queriable, InternalSignal};
+
+    #[test]
+    fn test_generate_random_assignment() {
+        let a: Queriable<Fr> = Queriable::Internal(InternalSignal::new("a"));
+        let b: Queriable<Fr> = Queriable::Internal(InternalSignal::new("b"));
+        let c: Queriable<Fr> = Queriable::Internal(InternalSignal::new("c"));
+        let d: Queriable<Fr> = Queriable::Internal(InternalSignal::new("d"));
+        let e: Queriable<Fr> = Queriable::Internal(InternalSignal::new("e"));
+        let f: Queriable<Fr> = Queriable::Internal(InternalSignal::new("f"));
+        let g: Queriable<Fr> = Queriable::Internal(InternalSignal::new("g"));
+        let vars = vec![a, b, c, d, e, f, g];
+
+        let keys: HashSet<Queriable<Fr>> = vars.iter().cloned().collect();
+
+        let assignments = generate_random_assignment::<Fr, Queriable<Fr>>(keys.clone());
+
+        for key in &keys {
+            assert!(assignments.contains_key(key));
+        }
+    }
+
+    #[test]
+    fn test_cse() {
+        todo!()
+    }
+}

--- a/src/poly/cse.rs
+++ b/src/poly/cse.rs
@@ -91,7 +91,7 @@ mod test {
         println!("Assignments: {:#?}", assignments);
 
         for key in &keys {
-            assert!(assignments.contains_key(&key));
+            assert!(assignments.contains_key(key));
         }
     }
 
@@ -127,8 +127,8 @@ mod test {
         assert!(Rc::ptr_eq(&result[0], &result[1]));
         assert!(Rc::ptr_eq(&result[2], &result[3]));
         assert!(Rc::ptr_eq(&result[4], &result[5]));
-        assert!(Rc::ptr_eq(&result[0], &result[2]) == false);
-        assert!(Rc::ptr_eq(&result[0], &result[4]) == false);
-        assert!(Rc::ptr_eq(&result[2], &result[4]) == false);
+        assert!(!Rc::ptr_eq(&result[0], &result[2]));
+        assert!(!Rc::ptr_eq(&result[0], &result[4]));
+        assert!(!Rc::ptr_eq(&result[2], &result[4]));
     }
 }

--- a/src/poly/mod.rs
+++ b/src/poly/mod.rs
@@ -71,13 +71,11 @@ pub struct HashResult {
 
 impl<F: Field + Hash, V: Debug + Clone + Eq + Hash> Expr<F, V, ()> {
     /// Uses Schwartz-Zippel Lemma to hash
-    pub fn hash(&self, assignments: &[VarAssignments<F, V>]) -> Expr<F, V, HashResult> {
+    pub fn hash(&self, assignments: &VarAssignments<F, V>) -> Expr<F, V, HashResult> {
         let mut hasher = DefaultHasher::new();
 
-        for assignment in assignments {
-            if let Some(result) = self.eval(assignment) {
-                result.hash(&mut hasher);
-            }
+        if let Some(result) = self.eval(assignments) {
+            result.hash(&mut hasher);
         }
 
         let hash_result = HashResult {
@@ -507,13 +505,9 @@ mod test {
         let g: Queriable<Fr> = Queriable::Internal(InternalSignal::new("g"));
         let vars = vec![a, b, c, d, e, f, g];
 
-        let mut assignments_vec = Vec::new();
-        for _ in 0..6 {
-            let mut assignments = VarAssignments::new();
-            for v in &vars {
-                assignments.insert(*v, Fr::random(&mut rng));
-            }
-            assignments_vec.push(assignments);
+        let mut assignments = VarAssignments::new();
+        for v in &vars {
+            assignments.insert(*v, Fr::random(&mut rng));
         }
 
         // Equivalent expressions
@@ -532,7 +526,7 @@ mod test {
         let mut hashed_expressions = Vec::new();
 
         for expr in expressions {
-            let hashed_expr = expr.hash(&assignments_vec);
+            let hashed_expr = expr.hash(&assignments);
             hashed_expressions.push(hashed_expr);
         }
 

--- a/src/poly/mod.rs
+++ b/src/poly/mod.rs
@@ -506,7 +506,7 @@ mod test {
 
         // Equivalent expressions
         let expr3 = f * b - c * d - 1.expr();
-        let expr4 = -1.expr() - c * d + b * f;
+        let expr4 = -(1.expr()) - c * d + b * f;
 
         // Equivalent expressions
         let expr5 = -(-f * g) * (-(-(-a)));

--- a/src/sbpir/mod.rs
+++ b/src/sbpir/mod.rs
@@ -480,23 +480,23 @@ pub struct ForwardSignal {
 }
 
 impl ForwardSignal {
-    pub fn new(annotation: String) -> ForwardSignal {
-        Self::new_with_id(uuid(), 0, annotation)
+    pub fn new<S: Into<String>>(annotation: S) -> ForwardSignal {
+        Self::new_with_id(uuid(), 0, annotation.into())
     }
 
-    pub fn new_with_phase(phase: usize, annotation: String) -> ForwardSignal {
+    pub fn new_with_phase<S: Into<String>>(phase: usize, annotation: S) -> ForwardSignal {
         ForwardSignal {
             id: uuid(),
             phase,
-            annotation: Box::leak(annotation.into_boxed_str()),
+            annotation: Box::leak(annotation.into().into_boxed_str()),
         }
     }
 
-    pub fn new_with_id(id: UUID, phase: usize, annotation: String) -> Self {
+    pub fn new_with_id<S: Into<String>>(id: UUID, phase: usize, annotation: S) -> Self {
         Self {
             id,
             phase,
-            annotation: Box::leak(annotation.into_boxed_str()),
+            annotation: Box::leak(annotation.into().into_boxed_str()),
         }
     }
 
@@ -521,19 +521,19 @@ pub struct SharedSignal {
 }
 
 impl SharedSignal {
-    pub fn new_with_phase(phase: usize, annotation: String) -> SharedSignal {
+    pub fn new_with_phase<S: Into<String>>(phase: usize, annotation: S) -> SharedSignal {
         SharedSignal {
             id: uuid(),
             phase,
-            annotation: Box::leak(annotation.into_boxed_str()),
+            annotation: Box::leak(annotation.into().into_boxed_str()),
         }
     }
 
-    pub fn new_with_id(id: UUID, phase: usize, annotation: String) -> Self {
+    pub fn new_with_id<S: Into<String>>(id: UUID, phase: usize, annotation: S) -> Self {
         Self {
             id,
             phase,
-            annotation: Box::leak(annotation.into_boxed_str()),
+            annotation: Box::leak(annotation.into().into_boxed_str()),
         }
     }
 
@@ -557,17 +557,17 @@ pub struct FixedSignal {
 }
 
 impl FixedSignal {
-    pub fn new(annotation: String) -> FixedSignal {
+    pub fn new<S: Into<String>>(annotation: S) -> FixedSignal {
         FixedSignal {
             id: uuid(),
-            annotation: Box::leak(annotation.into_boxed_str()),
+            annotation: Box::leak(annotation.into().into_boxed_str()),
         }
     }
 
-    pub fn new_with_id(id: UUID, annotation: String) -> Self {
+    pub fn new_with_id<S: Into<String>>(id: UUID, annotation: S) -> Self {
         Self {
             id,
-            annotation: Box::leak(annotation.into_boxed_str()),
+            annotation: Box::leak(annotation.into().into_boxed_str()),
         }
     }
 
@@ -600,10 +600,10 @@ impl InternalSignal {
         }
     }
 
-    pub fn new_with_id(id: UUID, annotation: String) -> Self {
+    pub fn new_with_id<S: Into<String>>(id: UUID, annotation: S) -> Self {
         Self {
             id,
-            annotation: Box::leak(annotation.into_boxed_str()),
+            annotation: Box::leak(annotation.into().into_boxed_str()),
         }
     }
 

--- a/src/wit_gen.rs
+++ b/src/wit_gen.rs
@@ -324,15 +324,15 @@ mod tests {
                     StepInstance {
                         step_type_uuid: 9,
                         assignments: HashMap::from([
-                            (Queriable::Fixed(FixedSignal::new("a".into()), 0), 1),
-                            (Queriable::Fixed(FixedSignal::new("b".into()), 0), 2)
+                            (Queriable::Fixed(FixedSignal::new("a"), 0), 1),
+                            (Queriable::Fixed(FixedSignal::new("b"), 0), 2)
                         ]),
                     },
                     StepInstance {
                         step_type_uuid: 10,
                         assignments: HashMap::from([
-                            (Queriable::Fixed(FixedSignal::new("a".into()), 0), 1),
-                            (Queriable::Fixed(FixedSignal::new("b".into()), 0), 2)
+                            (Queriable::Fixed(FixedSignal::new("a"), 0), 1),
+                            (Queriable::Fixed(FixedSignal::new("b"), 0), 2)
                         ]),
                     }
                 ]


### PR DESCRIPTION
Hash function for `Expr` nodes using Schwartz-Zippel Lemma: takes an array of variable assignments and hashes the expression based on the evaluation for every assignments