### PR TITLE
removed big endian arch target from the PyPi publish workflow

### DIFF
--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        target: [x86_64, x86, aarch64, armv7, s390x, ppc64le]
+        target: [x86_64, x86, aarch64, armv7, ppc64le]
     steps:
       - name: Checkout repository and submodules
         uses: actions/checkout@v2


### PR DESCRIPTION
So the issue was initiated when HyperPlonk was merged, because it introduced that library which is incompatible with big endian architecture. Is it relevant to be able to run current version of Chiquito for big endian arch or can we delete this from the workflow? @leolara 
More details here:
https://github.com/privacy-scaling-explorations/chiquito/issues/260#issuecomment-2156438195
The library in question is aware of this issue but it still does not provide any fix for it.