### PR TITLE
Fix definition references for declarations

### DIFF
--- a/src/compiler/semantic/analyser.rs
+++ b/src/compiler/semantic/analyser.rs
@@ -55,13 +55,18 @@ impl Analyser {
     fn analyse_tldcl(&mut self, decl: &TLDecl<BigInt, Identifier>) {
         match decl.clone() {
             TLDecl::MachineDecl {
-                dsym,
+                dsym: _,
                 id,
                 input_params,
                 output_params,
                 block,
             } => {
-                let sym = SymTableEntry::new(id.name(), dsym, SymbolCategory::Machine, None);
+                let sym = SymTableEntry::new(
+                    id.name(),
+                    id.debug_sym_ref(),
+                    SymbolCategory::Machine,
+                    None,
+                );
 
                 RULES.apply_new_symbol_tldecl(self, decl, &id, &sym);
 
@@ -93,10 +98,10 @@ impl Analyser {
 
     fn analyse_machine_input_params(&mut self, params: Vec<Statement<BigInt, Identifier>>) {
         params.iter().for_each(|param| match param {
-            Statement::SignalDecl(dsym, ids) => ids.iter().for_each(|id| {
+            Statement::SignalDecl(_, ids) => ids.iter().for_each(|id| {
                 let sym = SymTableEntry::new(
                     id.id.name(),
-                    dsym.clone(),
+                    id.id.debug_sym_ref(),
                     SymbolCategory::InputSignal,
                     id.ty.clone().map(|ty| ty.name()),
                 );
@@ -105,10 +110,10 @@ impl Analyser {
 
                 self.symbols.add_symbol(&self.cur_scope, id.id.name(), sym);
             }),
-            Statement::WGVarDecl(dsym, ids) => ids.iter().for_each(|id| {
+            Statement::WGVarDecl(_, ids) => ids.iter().for_each(|id| {
                 let sym = SymTableEntry::new(
                     id.id.name(),
-                    dsym.clone(),
+                    id.id.debug_sym_ref(),
                     SymbolCategory::InputWGVar,
                     id.ty.clone().map(|ty| ty.name()),
                 );
@@ -123,10 +128,10 @@ impl Analyser {
 
     fn analyse_machine_output_params(&mut self, params: Vec<Statement<BigInt, Identifier>>) {
         params.iter().for_each(|param| match param {
-            Statement::SignalDecl(dsym, ids) => ids.iter().for_each(|id| {
+            Statement::SignalDecl(_, ids) => ids.iter().for_each(|id| {
                 let sym = SymTableEntry::new(
                     id.id.name(),
-                    dsym.clone(),
+                    id.id.debug_sym_ref(),
                     SymbolCategory::OutputSignal,
                     id.ty.clone().map(|ty| ty.name()),
                 );
@@ -136,10 +141,10 @@ impl Analyser {
                 self.symbols
                     .add_output_variable(&self.cur_scope, id.id.name(), sym);
             }),
-            Statement::WGVarDecl(dsym, ids) => ids.iter().for_each(|id| {
+            Statement::WGVarDecl(_, ids) => ids.iter().for_each(|id| {
                 let sym = SymTableEntry::new(
                     id.id.name(),
-                    dsym.clone(),
+                    id.id.debug_sym_ref(),
                     SymbolCategory::OutputWGVar,
                     id.ty.clone().map(|ty| ty.name()),
                 );
@@ -160,9 +165,13 @@ impl Analyser {
     fn add_state_decls(&mut self, block: &Statement<BigInt, Identifier>) {
         if let Statement::Block(_, stmts) = block {
             stmts.iter().for_each(|stmt| {
-                if let Statement::StateDecl(dsym, id, _) = stmt {
-                    let sym =
-                        SymTableEntry::new(id.name(), dsym.clone(), SymbolCategory::State, None);
+                if let Statement::StateDecl(_, id, _) = stmt {
+                    let sym = SymTableEntry::new(
+                        id.name(),
+                        id.debug_sym_ref(),
+                        SymbolCategory::State,
+                        None,
+                    );
 
                     RULES.apply_new_symbol_statement(self, stmt, id, &sym);
 
@@ -211,10 +220,10 @@ impl Analyser {
 
     fn statement_add_symbols(&mut self, stmt: &Statement<BigInt, Identifier>) {
         match stmt.clone() {
-            Statement::SignalDecl(dsym, ids) => ids.into_iter().for_each(|id| {
+            Statement::SignalDecl(_, ids) => ids.into_iter().for_each(|id| {
                 let sym = SymTableEntry::new(
                     id.id.name(),
-                    dsym.clone(),
+                    id.id.debug_sym_ref(),
                     SymbolCategory::Signal,
                     id.ty.map(|ty| ty.name()),
                 );
@@ -223,10 +232,10 @@ impl Analyser {
 
                 self.symbols.add_symbol(&self.cur_scope, id.id.name(), sym);
             }),
-            Statement::WGVarDecl(dsym, ids) => ids.into_iter().for_each(|id| {
+            Statement::WGVarDecl(_, ids) => ids.into_iter().for_each(|id| {
                 let sym = SymTableEntry::new(
                     id.id.name(),
-                    dsym.clone(),
+                    id.id.debug_sym_ref(),
                     SymbolCategory::WGVar,
                     id.ty.map(|ty| ty.name()),
                 );
@@ -397,7 +406,7 @@ mod test {
 
         assert_eq!(
             format!("{:?}", result),
-            r#"AnalysisResult { symbols: "/": ScopeTable { symbols: "\"fibo\": SymTableEntry { id: \"fibo\", definition_ref: DebugSymRef { start: \"2:9\", end: \"40:13\" }, usages: [], category: Machine, ty: None }", scope: Global },"//fibo": ScopeTable { symbols: "\"a\": SymTableEntry { id: \"a\", definition_ref: DebugSymRef { line: 5, cols: \"13-32\" }, usages: [DebugSymRef { line: 13, cols: \"17-18\" }, DebugSymRef { line: 16, cols: \"15-17\" }, DebugSymRef { line: 23, cols: \"20-21\" }, DebugSymRef { line: 31, cols: \"20-22\" }], category: Signal, ty: Some(\"field\") },\"b\": SymTableEntry { id: \"b\", definition_ref: DebugSymRef { line: 2, cols: \"33-48\" }, usages: [DebugSymRef { line: 13, cols: \"20-21\" }, DebugSymRef { line: 16, cols: \"30-31\" }, DebugSymRef { line: 16, cols: \"19-21\" }, DebugSymRef { line: 23, cols: \"24-25\" }, DebugSymRef { line: 27, cols: \"20-22\" }, DebugSymRef { line: 31, cols: \"42-43\" }, DebugSymRef { line: 31, cols: \"24-26\" }], category: OutputSignal, ty: Some(\"field\") },\"final\": SymTableEntry { id: \"final\", definition_ref: DebugSymRef { start: \"2:50\", end: \"40:13\" }, usages: [DebugSymRef { line: 26, cols: \"18-23\" }], category: State, ty: None },\"i\": SymTableEntry { id: \"i\", definition_ref: DebugSymRef { line: 5, cols: \"13-32\" }, usages: [DebugSymRef { line: 13, cols: \"14-15\" }, DebugSymRef { line: 25, cols: \"17-18\" }, DebugSymRef { line: 27, cols: \"31-32\" }, DebugSymRef { line: 27, cols: \"16-18\" }, DebugSymRef { line: 31, cols: \"35-36\" }, DebugSymRef { line: 31, cols: \"16-18\" }], category: Signal, ty: None },\"initial\": SymTableEntry { id: \"initial\", definition_ref: DebugSymRef { start: \"10:13\", end: \"18:14\" }, usages: [], category: State, ty: None },\"middle\": SymTableEntry { id: \"middle\", definition_ref: DebugSymRef { start: \"20:13\", end: \"34:14\" }, usages: [DebugSymRef { line: 15, cols: \"17-23\" }, DebugSymRef { line: 30, cols: \"18-24\" }], category: State, ty: None },\"n\": SymTableEntry { id: \"n\", definition_ref: DebugSymRef { line: 2, cols: \"22-30\" }, usages: [DebugSymRef { line: 16, cols: \"36-37\" }, DebugSymRef { line: 16, cols: \"23-25\" }, DebugSymRef { line: 25, cols: \"26-27\" }, DebugSymRef { line: 27, cols: \"41-42\" }, DebugSymRef { line: 27, cols: \"24-26\" }, DebugSymRef { line: 31, cols: \"48-49\" }, DebugSymRef { line: 31, cols: \"28-30\" }], category: InputSignal, ty: None }", scope: Machine },"//fibo/final": ScopeTable { symbols: "", scope: State },"//fibo/initial": ScopeTable { symbols: "\"c\": SymTableEntry { id: \"c\", definition_ref: DebugSymRef { line: 11, cols: \"14-23\" }, usages: [DebugSymRef { line: 13, cols: \"23-24\" }, DebugSymRef { line: 16, cols: \"33-34\" }], category: Signal, ty: None }", scope: State },"//fibo/middle": ScopeTable { symbols: "\"c\": SymTableEntry { id: \"c\", definition_ref: DebugSymRef { line: 21, cols: \"14-23\" }, usages: [DebugSymRef { line: 23, cols: \"14-15\" }, DebugSymRef { line: 27, cols: \"38-39\" }, DebugSymRef { line: 31, cols: \"45-46\" }], category: Signal, ty: None }", scope: State }, messages: [] }"#
+            r#"AnalysisResult { symbols: "/": ScopeTable { symbols: "\"fibo\": SymTableEntry { id: \"fibo\", definition_ref: DebugSymRef { line: 2, cols: \"17-21\" }, usages: [], category: Machine, ty: None }", scope: Global },"//fibo": ScopeTable { symbols: "\"a\": SymTableEntry { id: \"a\", definition_ref: DebugSymRef { line: 5, cols: \"20-21\" }, usages: [DebugSymRef { line: 13, cols: \"17-18\" }, DebugSymRef { line: 16, cols: \"15-17\" }, DebugSymRef { line: 23, cols: \"20-21\" }, DebugSymRef { line: 31, cols: \"20-22\" }], category: Signal, ty: Some(\"field\") },\"b\": SymTableEntry { id: \"b\", definition_ref: DebugSymRef { line: 2, cols: \"40-41\" }, usages: [DebugSymRef { line: 13, cols: \"20-21\" }, DebugSymRef { line: 16, cols: \"30-31\" }, DebugSymRef { line: 16, cols: \"19-21\" }, DebugSymRef { line: 23, cols: \"24-25\" }, DebugSymRef { line: 27, cols: \"20-22\" }, DebugSymRef { line: 31, cols: \"42-43\" }, DebugSymRef { line: 31, cols: \"24-26\" }], category: OutputSignal, ty: Some(\"field\") },\"final\": SymTableEntry { id: \"final\", definition_ref: DebugSymRef { start: \"2:50\", end: \"40:13\" }, usages: [DebugSymRef { line: 26, cols: \"18-23\" }], category: State, ty: None },\"i\": SymTableEntry { id: \"i\", definition_ref: DebugSymRef { line: 5, cols: \"30-31\" }, usages: [DebugSymRef { line: 13, cols: \"14-15\" }, DebugSymRef { line: 25, cols: \"17-18\" }, DebugSymRef { line: 27, cols: \"31-32\" }, DebugSymRef { line: 27, cols: \"16-18\" }, DebugSymRef { line: 31, cols: \"35-36\" }, DebugSymRef { line: 31, cols: \"16-18\" }], category: Signal, ty: None },\"initial\": SymTableEntry { id: \"initial\", definition_ref: DebugSymRef { line: 10, cols: \"19-26\" }, usages: [], category: State, ty: None },\"middle\": SymTableEntry { id: \"middle\", definition_ref: DebugSymRef { line: 20, cols: \"19-25\" }, usages: [DebugSymRef { line: 15, cols: \"17-23\" }, DebugSymRef { line: 30, cols: \"18-24\" }], category: State, ty: None },\"n\": SymTableEntry { id: \"n\", definition_ref: DebugSymRef { line: 2, cols: \"29-30\" }, usages: [DebugSymRef { line: 16, cols: \"36-37\" }, DebugSymRef { line: 16, cols: \"23-25\" }, DebugSymRef { line: 25, cols: \"26-27\" }, DebugSymRef { line: 27, cols: \"41-42\" }, DebugSymRef { line: 27, cols: \"24-26\" }, DebugSymRef { line: 31, cols: \"48-49\" }, DebugSymRef { line: 31, cols: \"28-30\" }], category: InputSignal, ty: None }", scope: Machine },"//fibo/final": ScopeTable { symbols: "", scope: State },"//fibo/initial": ScopeTable { symbols: "\"c\": SymTableEntry { id: \"c\", definition_ref: DebugSymRef { line: 11, cols: \"21-22\" }, usages: [DebugSymRef { line: 13, cols: \"23-24\" }, DebugSymRef { line: 16, cols: \"33-34\" }], category: Signal, ty: None }", scope: State },"//fibo/middle": ScopeTable { symbols: "\"c\": SymTableEntry { id: \"c\", definition_ref: DebugSymRef { line: 21, cols: \"21-22\" }, usages: [DebugSymRef { line: 23, cols: \"14-15\" }, DebugSymRef { line: 27, cols: \"38-39\" }, DebugSymRef { line: 31, cols: \"45-46\" }], category: Signal, ty: None }", scope: State }, messages: [] }"#
         )
     }
 }

--- a/src/compiler/semantic/mod.rs
+++ b/src/compiler/semantic/mod.rs
@@ -531,8 +531,8 @@ mod test {
         let test_cases = [
             (396, "a"),
             (397, "a"),
-            (395, "initial"),
-            (398, "initial"),
+            (395, "final"),
+            (398, "final"),
             (460, "a"),
             (584, "a"),
             (772, "a"),


### PR DESCRIPTION
There was a small issue with how we were recording the definition references for declarations. We were counting the whole entry of the AST as its definition. For example, here:
```
state new_state {
...
}
```
the definition start was the start of the word "state" and the end was the closing curly bracket. This PR fixes the definition references to be the span of the identifier (in this example, just the `new_state`). 
Benefits:
- allows to distinguish between comma-separated declarations (which otherwise would have the same dsym value);
- enables the language server to correctly identify the symbols.