### PR TITLE
Expose debug symbol start and end for the language server

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,18 +8,18 @@ authors = ["Leo Lara <leo@leolara.me>"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [patch.crates-io]
-halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", default-features = false, rev = "da4983e" }
+halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", default-features = false, rev = "bc857a7" }
 
 [patch."https://github.com/scroll-tech/halo2.git"]
-halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", default-features = false, rev = "da4983e" }
+halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", default-features = false, rev = "bc857a7" }
 
 [dependencies]
 pyo3 = { version = "0.19.1", features = ["extension-module"] }
 
-halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", default-features = false, features = [ "circuit-params", "derive_serde"], rev = "da4983e"}
+halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", default-features = false, features = [ "circuit-params", "derive_serde"], rev = "bc857a7"}
 
-halo2_middleware = { git = "https://github.com/privacy-scaling-explorations/halo2.git", rev = "da4983e" }
-halo2_backend = { git = "https://github.com/privacy-scaling-explorations/halo2.git", features = ["derive_serde"], rev = "da4983e" }
+halo2_middleware = { git = "https://github.com/privacy-scaling-explorations/halo2.git", rev = "bc857a7" }
+halo2_backend = { git = "https://github.com/privacy-scaling-explorations/halo2.git", features = ["derive_serde"], rev = "bc857a7" }
 
 num-bigint = { version = "0.4", features = ["rand"] }
 uuid = { version = "1.4.0", features = ["v1", "rng"] }

--- a/src/parser/ast/mod.rs
+++ b/src/parser/ast/mod.rs
@@ -142,12 +142,14 @@ impl PartialEq for DebugSymRef {
 }
 
 /// Interface of the debug symbol reference to use with the Chiquito language server
-pub trait LanguageServerInterface {
+pub trait Spanned {
+    /// Get span start
     fn get_start(&self) -> usize;
+    /// Get span end
     fn get_end(&self) -> usize;
 }
 
-impl LanguageServerInterface for DebugSymRef {
+impl Spanned for DebugSymRef {
     fn get_start(&self) -> usize {
         self.start
     }
@@ -243,7 +245,7 @@ mod test {
 
     use codespan_reporting::files::SimpleFile;
 
-    use crate::parser::ast::{DebugSymRef, Identifier, LanguageServerInterface};
+    use crate::parser::ast::{DebugSymRef, Identifier, Spanned};
 
     #[test]
     fn test_language_server_interface() {

--- a/src/parser/ast/mod.rs
+++ b/src/parser/ast/mod.rs
@@ -141,6 +141,22 @@ impl PartialEq for DebugSymRef {
     }
 }
 
+/// Interface of the debug symbol reference to use with the Chiquito language server
+pub trait LanguageServerInterface {
+    fn get_start(&self) -> usize;
+    fn get_end(&self) -> usize;
+}
+
+impl LanguageServerInterface for DebugSymRef {
+    fn get_start(&self) -> usize {
+        self.start
+    }
+
+    fn get_end(&self) -> usize {
+        self.end
+    }
+}
+
 #[derive(Clone, PartialEq, Eq)]
 pub struct Identifier(
     /// Name
@@ -227,7 +243,20 @@ mod test {
 
     use codespan_reporting::files::SimpleFile;
 
-    use crate::parser::ast::{DebugSymRef, Identifier};
+    use crate::parser::ast::{DebugSymRef, Identifier, LanguageServerInterface};
+
+    #[test]
+    fn test_language_server_interface() {
+        let debug_sym_ref = DebugSymRef {
+            start: 0,
+            end: 1,
+            file: Arc::new(SimpleFile::new("file_path".to_string(), "".to_string())),
+            virt: false,
+        };
+
+        assert_eq!(debug_sym_ref.get_start(), 0);
+        assert_eq!(debug_sym_ref.get_end(), 1);
+    }
 
     #[test]
     fn test_from_string() {


### PR DESCRIPTION
We have accidentally made the start and end of debug symbol private, so here's a fix for the language server. Also had to update the halo2 to the latest version because the language server didn't want to compile (there was a missing bound on a variable generic inside the halo2 middleware `Expression`, not sure why Chiquito itself compiled successfully).