### PR TITLE
Rutefig/274 using m type to keep debugsym in expr

### DIFF
--- a/src/poly/mod.rs
+++ b/src/poly/mod.rs
@@ -91,14 +91,14 @@ impl<F: Clone, V: Clone, M> Expr<F, V, M> {
     }
 }
 
-impl<F: Field + Hash, V: Debug + Clone + Eq + Hash, M: Clone> Expr<F, V, M> {
+impl<F: Clone, V: Debug + Clone + Eq, M: Clone> Expr<F, V, M> {
     pub fn transform_meta<N: Clone, ApplyMetaFn>(&self, apply_meta: ApplyMetaFn) -> Expr<F, V, N>
     where
         ApplyMetaFn: Fn(&Expr<F, V, M>) -> N + Clone,
     {
         let new_meta = apply_meta(self);
         match self {
-            Expr::Const(v, _) => Expr::Const(*v, new_meta),
+            Expr::Const(v, _) => Expr::Const(v.clone(), new_meta),
             Expr::Sum(ses, _) => Expr::Sum(
                 ses.iter()
                     .map(|e| e.transform_meta(apply_meta.clone()))


### PR DESCRIPTION
This PR is applying the Debug Symbol for each expression on the AST to the constraints resulting from the compilation present on the SBPIR. The Debug Symbol was being lost on the Setup Interpreter.

It refers to the issue #274 